### PR TITLE
Add support for end of the month reminders

### DIFF
--- a/CryptoTechReminderSystem.AcceptanceTest/ApiEndpointResponse/HarvestTimeEntriesEndOfTheMonthResponse.json
+++ b/CryptoTechReminderSystem.AcceptanceTest/ApiEndpointResponse/HarvestTimeEntriesEndOfTheMonthResponse.json
@@ -1,0 +1,65 @@
+{
+  "time_entries":[
+    {
+      "id":636709355,
+      "spent_date":"2019-07-29",
+      "user":{
+        "id":1782974,
+        "name":"Bruce Wayne"
+      },
+      "hours":7.0,
+      "created_at":"2019-03-01T10:00:00Z",
+      "updated_at":"2019-03-01T10:00:00Z"
+    },
+    {
+      "id":636709356,
+      "spent_date":"2019-07-30",
+      "user":{
+        "id":1782974,
+        "name":"Bruce Wayne"
+      },
+      "hours":7.0,
+      "created_at":"2019-03-01T10:05:00Z",
+      "updated_at":"2019-03-01T10:05:00Z"
+    },
+    {
+      "id":636709357,
+      "spent_date":"2019-07-31",
+      "user":{
+        "id":1782974,
+        "name":"Bruce Wayne"
+      },
+      "hours":7.0,
+      "created_at":"2019-03-01T10:06:00Z",
+      "updated_at":"2019-03-01T10:06:00Z"
+    },
+    {
+      "id":636709358,
+      "spent_date":"2019-07-29",
+      "user":{
+        "id":1902070,
+        "name":"Harvey Dent"
+      },
+      "hours":7.0,
+      "created_at":"2019-03-01T10:07:00Z",
+      "updated_at":"2019-03-01T10:07:00Z"
+    },
+    {
+      "id":636709359,
+      "spent_date":"2019-07-30",
+      "user":{
+        "id":1902070,
+        "name":"Harvey Dent"
+      },
+      "hours":7.0,
+      "created_at":"2019-03-01T10:08:00Z",
+      "updated_at":"2019-03-01T10:08:00Z"
+    }
+  ],
+  "per_page":100,
+  "total_pages":1,
+  "total_entries":5,
+  "next_page":null,
+  "previous_page":null,
+  "page":1
+}

--- a/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
+++ b/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
@@ -166,8 +166,8 @@ namespace CryptoTechReminderSystem.AcceptanceTest
             );
             
             _slackApi.ReceivedRequests.Should()
-                .Contain(request => request.RawUrl.ToString() == "/api/users.list");   
-            _slackApi.ReceivedRequests.Count(request => request.RawUrl.ToString() == "/api/chat.postMessage")
+                .Contain(request => request.RawUrl.ToString() == "/" + SlackApiUsersPath);   
+            _slackApi.ReceivedRequests.Count(request => request.RawUrl.ToString() == "/" + SlackApiPostMessagePath)
                 .Should().Be(3);
         }
         

--- a/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
+++ b/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
@@ -82,11 +82,25 @@ namespace CryptoTechReminderSystem.AcceptanceTest
                     "../../../ApiEndpointResponse/HarvestTimeEntriesResponse.json"
                 )
             );
+            
+            var harvestGetTimeEntriesResponseEndOfTheMonth = File.ReadAllText(
+                Path.Combine(
+                    AppDomain.CurrentDomain.BaseDirectory,
+                    "../../../ApiEndpointResponse/HarvestTimeEntriesEndOfTheMonthResponse.json"
+                )
+            );
+            
             _harvestApi.Get("/api/v2/time_entries")
                 .WithParameter("from", "2019-02-25")
                 .WithParameter("to", "2019-03-01")
                 .WithParameter("page", "1")
                 .Responds(harvestGetTimeEntriesResponse);
+            
+            _harvestApi.Get("/api/v2/time_entries")
+                .WithParameter("from", "2019-07-29")
+                .WithParameter("to", "2019-07-31")
+                .WithParameter("page", "1")
+                .Responds(harvestGetTimeEntriesResponseEndOfTheMonth);
             
             _slackApi.Start();
             _harvestApi.Start();
@@ -106,7 +120,7 @@ namespace CryptoTechReminderSystem.AcceptanceTest
         }
 
         [Test]
-        public void CanRemindLateDevelopers()
+        public void CanRemindLateDevelopersOnAFriday()
         {                      
             var clock = new ClockStub(
                 new DateTimeOffset(
@@ -129,6 +143,32 @@ namespace CryptoTechReminderSystem.AcceptanceTest
             
             _slackApi.ReceivedRequests.Should()
                 .Contain(request => request.Url.ToString() == SlackApiAddress + SlackApiPostMessagePath);   
+        }
+        
+        [Test]
+        public void CanRemindLateDevelopersEndOfTheMonth()
+        {                      
+            var clock = new ClockStub(
+                new DateTimeOffset(
+                    new DateTime(2019, 07, 31, 10, 30, 0)
+                )
+            );
+            
+            var getLateDevelopers = new GetLateDevelopers(_slackGateway, _harvestGateway, _harvestGateway, clock);
+            
+            var remindLateDevelopers = new RemindLateDevelopers(getLateDevelopers, _sendReminder);
+
+            remindLateDevelopers.Execute(
+                new RemindLateDevelopersRequest
+                {
+                    Message = "Please make sure your timesheet is submitted by 13:30 today."
+                }
+            );
+            
+            _slackApi.ReceivedRequests.Should()
+                .Contain(request => request.RawUrl.ToString() == "/api/users.list");   
+            _slackApi.ReceivedRequests.Count(request => request.RawUrl.ToString() == "/api/chat.postMessage")
+                .Should().Be(3);
         }
         
         [Test]

--- a/CryptoTechReminderSystem.Main/Program.cs
+++ b/CryptoTechReminderSystem.Main/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using CryptoTechReminderSystem.Boundary;
 using CryptoTechReminderSystem.Gateway;
@@ -60,6 +61,11 @@ namespace CryptoTechReminderSystem.Main
         
         private void CreateSchedule()
         {
+            if (!IsLastDayOfTheMonthFridayOrWeekend())
+            {
+                JobManager.AddJob(ScheduleJobs, s => s.ToRunEvery(0).Months().OnTheLastDay().At(10, 25));
+                JobManager.AddJob(ResetSchedule, s => s.ToRunEvery(0).Months().OnTheLastDay().At(13,45));  
+            }
             JobManager.AddJob(ScheduleJobs, s => s.ToRunEvery(0).Weeks().On(DayOfWeek.Friday).At(10,25));
             JobManager.AddJob(ResetSchedule, s => s.ToRunEvery(0).Weeks().On(DayOfWeek.Friday).At(13,45));
         }
@@ -91,6 +97,22 @@ namespace CryptoTechReminderSystem.Main
                     Channel = Environment.GetEnvironmentVariable("SLACK_CHANNEL_ID")
                 }
             );
+        }
+        
+        private bool IsLastDayOfTheMonthFridayOrWeekend()
+        {
+            var lastDayOfTheMonth = DateTime.DaysInMonth(DateTimeOffset.Now.Year, DateTimeOffset.Now.Month);
+            
+            var lastDayOfTheMonthDayOfWeek = new DateTimeOffset(
+                new DateTime(DateTimeOffset.Now.Year, DateTimeOffset.Now.Month, lastDayOfTheMonth)
+            ).DayOfWeek;
+            
+            return new List<DayOfWeek>
+            {   
+                DayOfWeek.Friday, 
+                DayOfWeek.Saturday, 
+                DayOfWeek.Sunday
+            }.Contains(lastDayOfTheMonthDayOfWeek);
         }
     }
 }

--- a/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
@@ -225,8 +225,8 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 var getLateDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
                 var response = getLateDevelopers.Execute();
                 
-                response.Developers.Any(developer => developer.Id == lateUsersSlackUserId).Should().BeTrue();
-                response.Developers.Any(developer => developer.Id == submittingUserSlackUserId).Should().BeFalse();
+                response.Developers.Should().Contain(developer => developer.Id == lateUsersSlackUserId);
+                response.Developers.Should().NotContain(developer => developer.Id == submittingUserSlackUserId);
             }
             
             [Test]
@@ -245,7 +245,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 var getLateDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
                 var response = getLateDevelopers.Execute();
 
-                response.Developers.Count.Should().Be(0);
+                response.Developers.Should().HaveCount(0);
             }
         } 
 

--- a/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
@@ -203,6 +203,50 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 response.Developers.Any(developer => developer.Id == lateUsersSlackUserId).Should().BeTrue();
                 response.Developers.Any(developer => developer.Id == submittingUserSlackUserId).Should().BeFalse();
             }
+            
+            [Test]
+            [TestCase(1337, 0, "U8723", "U9999")]
+            [TestCase(123, 1, "U9999", "U8723")]
+            public void CanGetLateADeveloperMidweek(int harvestUserId, int nonWorkedWeekDayForPartTime, string submittingUserSlackUserId, string lateUsersSlackUserId)
+            {
+                var clock = new ClockStub(
+                    new DateTimeOffset(
+                        new DateTime(2019, 04, 30, 10, 30, 0)
+                    )
+                );
+                
+                var workingDaysOnTheWeekByEndOfTheMonth = clock.Now().DayOfWeek - DayOfWeek.Monday + 1;
+                var expectedDays = workingDaysOnTheWeekByEndOfTheMonth - nonWorkedWeekDayForPartTime;
+                
+                _harvestGatewayStub.TimeSheets = Enumerable.Repeat(
+                    new TimeSheet { Hours = 7, UserId = harvestUserId }, expectedDays
+                ).ToArray();
+                
+                var getLateDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
+                var response = getLateDevelopers.Execute();
+                
+                response.Developers.Any(developer => developer.Id == lateUsersSlackUserId).Should().BeTrue();
+                response.Developers.Any(developer => developer.Id == submittingUserSlackUserId).Should().BeFalse();
+            }
+            
+            [Test]
+            public void CanNotGetLateDevelopersOnWeekend()
+            {
+                _harvestGatewayStub.TimeSheets = Enumerable.Repeat(
+                    new TimeSheet { Hours = 7, UserId = 000 }, 2
+                ).ToArray();
+                
+                var clock = new ClockStub(
+                    new DateTimeOffset(
+                        new DateTime(2019, 08, 31, 10, 30, 0)
+                    )
+                );
+                
+                var getLateDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
+                var response = getLateDevelopers.Execute();
+
+                response.Developers.Count.Should().Be(0);
+            }
         } 
 
         [TestFixture]


### PR DESCRIPTION
We want to remind developers to submit timesheets on the last day of the month.
This solution assumes that timesheets are submitted on each Friday and prompts for
submission for the missing hours on the last week of the month from Monday till the last day of the month(midweek).
The solution assumes that a part-time developer has their non-worked day at the beginning of the week.
No end of the month reminders are sent out on Fridays or during weekend.