### PR TITLE
Remove travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: csharp
-mono: none
-sudo: required
-dist: xenial
-dotnet: 2.2
-script:
-    - dotnet restore
-    - dotnet build
-    - dotnet test


### PR DESCRIPTION
### Context

We don't use Travis anymore, instead we use CircleCI.

### Changes proposed in this pull request

This PR removes `travis.yml`.

### Guidance to review

Makes sense?

### Link to issue/card

https://github.com/madetech/the-wolves/projects/2#card-35802658
