### PR TITLE
Rename every occurrences of Developers to BillablePeople 

### DIFF
--- a/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
+++ b/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
@@ -23,7 +23,7 @@ namespace CryptoTechReminderSystem.AcceptanceTest
         private static HarvestGateway _harvestGateway;
         private static SlackGateway _slackGateway;
         private static SendReminder _sendReminder;
-        private const string DeveloperRoles = 
+        private const string BillablePersonRoles = 
             "Software Engineer, Senior Software Engineer, Senior Engineer, Lead Engineer, " +
             "Delivery Manager, SRE, Consultant, Delivery Principal";
 
@@ -52,7 +52,7 @@ namespace CryptoTechReminderSystem.AcceptanceTest
                 "xxxx-xxxxxxxxx-xxxx",
                 "234567",
                 "The Wolves",
-                DeveloperRoles
+                BillablePersonRoles
             );
             _sendReminder = new SendReminder(_slackGateway);
             

--- a/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
+++ b/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
@@ -120,7 +120,7 @@ namespace CryptoTechReminderSystem.AcceptanceTest
         }
 
         [Test]
-        public void CanRemindLateDevelopersOnAFriday()
+        public void CanRemindLateBillablePeopleOnAFriday()
         {                      
             var clock = new ClockStub(
                 new DateTimeOffset(
@@ -128,12 +128,12 @@ namespace CryptoTechReminderSystem.AcceptanceTest
                 )
             );
             
-            var getLateDevelopers = new GetLateDevelopers(_slackGateway, _harvestGateway, _harvestGateway, clock);
+            var getLateBillablePeople = new GetLateBillablePeople(_slackGateway, _harvestGateway, _harvestGateway, clock);
 
-            var remindLateDevelopers = new RemindLateDevelopers(getLateDevelopers, _sendReminder);
+            var remindLateBillablePeople = new RemindLateBillablePeople(getLateBillablePeople, _sendReminder);
 
-            remindLateDevelopers.Execute(
-                new RemindLateDevelopersRequest
+            remindLateBillablePeople.Execute(
+                new RemindLateBillablePeopleRequest
                 {
                     Message = "Please make sure your timesheet is submitted by 13:30 today."
                 }
@@ -146,7 +146,7 @@ namespace CryptoTechReminderSystem.AcceptanceTest
         }
         
         [Test]
-        public void CanRemindLateDevelopersEndOfTheMonth()
+        public void CanRemindLateBillablePeopleEndOfTheMonth()
         {                      
             var clock = new ClockStub(
                 new DateTimeOffset(
@@ -154,12 +154,12 @@ namespace CryptoTechReminderSystem.AcceptanceTest
                 )
             );
             
-            var getLateDevelopers = new GetLateDevelopers(_slackGateway, _harvestGateway, _harvestGateway, clock);
+            var getLateBillablePeople = new GetLateBillablePeople(_slackGateway, _harvestGateway, _harvestGateway, clock);
             
-            var remindLateDevelopers = new RemindLateDevelopers(getLateDevelopers, _sendReminder);
+            var remindLateBillablePeople = new RemindLateBillablePeople(getLateBillablePeople, _sendReminder);
 
-            remindLateDevelopers.Execute(
-                new RemindLateDevelopersRequest
+            remindLateBillablePeople.Execute(
+                new RemindLateBillablePeopleRequest
                 {
                     Message = "Please make sure your timesheet is submitted by 13:30 today."
                 }
@@ -172,7 +172,7 @@ namespace CryptoTechReminderSystem.AcceptanceTest
         }
         
         [Test]
-        public void CanListLateDevelopers()
+        public void CanListLateBillablePeople()
         {
             var clock = new ClockStub(
                 new DateTimeOffset(
@@ -180,17 +180,17 @@ namespace CryptoTechReminderSystem.AcceptanceTest
                 )
             );
             
-            var getLateDevelopers = new GetLateDevelopers(_slackGateway, _harvestGateway, _harvestGateway, clock);
+            var getLateBillablePeople = new GetLateBillablePeople(_slackGateway, _harvestGateway, _harvestGateway, clock);
 
-            var listLateDevelopers = new ListLateDevelopers(getLateDevelopers, _sendReminder);
+            var listLateBillablePeople = new ListLateBillablePeople(getLateBillablePeople, _sendReminder);
 
-            const string lateDevelopersMessage = "These are the people yet to submit time sheets:";
+            const string lateBillablePeopleMessage = "These are the people yet to submit time sheets:";
             const string channel = "CHBUZLJT1";
             
-            listLateDevelopers.Execute(
-                new ListLateDevelopersRequest
+            listLateBillablePeople.Execute(
+                new ListLateBillablePeopleRequest
                 {
-                    LateDevelopersMessage = lateDevelopersMessage,
+                    LateBillablePeopleMessage = lateBillablePeopleMessage,
                     Channel = channel
                 }
             );
@@ -199,7 +199,7 @@ namespace CryptoTechReminderSystem.AcceptanceTest
 
             lastSlackApiRequest["channel"].ToString().Should().Be(channel);
 
-            var expectedMessage = $"{lateDevelopersMessage}\n• <@W123AROB>\n• <@W345ABAT>\n• <@W345ALFR>";
+            var expectedMessage = $"{lateBillablePeopleMessage}\n• <@W123AROB>\n• <@W345ABAT>\n• <@W345ALFR>";
             lastSlackApiRequest["text"].ToString().Should().Be(expectedMessage); 
         }
     }

--- a/CryptoTechReminderSystem.Main/Program.cs
+++ b/CryptoTechReminderSystem.Main/Program.cs
@@ -29,7 +29,7 @@ namespace CryptoTechReminderSystem.Main
 
     public class ReminderRegistry : Registry
     {
-        private readonly GetLateDevelopers _getLateDevelopers;
+        private readonly GetLateBillablePeople _getLateBillablePeople;
         private readonly SendReminder _sendReminder;
 
         public ReminderRegistry()
@@ -47,7 +47,7 @@ namespace CryptoTechReminderSystem.Main
             );
             
             var clock = new Clock();
-            _getLateDevelopers = new GetLateDevelopers(slackGateway, harvestGateway, harvestGateway, clock);
+            _getLateBillablePeople = new GetLateBillablePeople(slackGateway, harvestGateway, harvestGateway, clock);
             _sendReminder = new SendReminder(slackGateway);
 
             CreateSchedule();
@@ -72,29 +72,29 @@ namespace CryptoTechReminderSystem.Main
 
         private void ScheduleJobs()
         {
-            JobManager.AddJob(RemindLateDevelopersJob, s => s.ToRunOnceAt(10, 30).AndEvery(30).Minutes());
-            JobManager.AddJob(ListLateDevelopersJob, s => s.ToRunOnceAt(13, 30));
+            JobManager.AddJob(RemindLateBillablePeopleJob, s => s.ToRunOnceAt(10, 30).AndEvery(30).Minutes());
+            JobManager.AddJob(ListLateBillablePeopleJob, s => s.ToRunOnceAt(13, 30));
         }
         
-        private void RemindLateDevelopersJob()
+        private void RemindLateBillablePeopleJob()
         {
-            var remindLateDevelopers = new RemindLateDevelopers(_getLateDevelopers, _sendReminder);
-            remindLateDevelopers.Execute(
-                new RemindLateDevelopersRequest
+            var remindLateBillablePeople = new RemindLateBillablePeople(_getLateBillablePeople, _sendReminder);
+            remindLateBillablePeople.Execute(
+                new RemindLateBillablePeopleRequest
                 {
                     Message = Environment.GetEnvironmentVariable("SLACK_REMINDER_MESSAGE")
                 }
             );
         }
         
-        private void ListLateDevelopersJob()
+        private void ListLateBillablePeopleJob()
         {
-            var listLateDevelopers = new ListLateDevelopers(_getLateDevelopers, _sendReminder);
-            listLateDevelopers.Execute(
-                new ListLateDevelopersRequest
+            var listLateBillablePeople = new ListLateBillablePeople(_getLateBillablePeople, _sendReminder);
+            listLateBillablePeople.Execute(
+                new ListLateBillablePeopleRequest
                 {
-                    LateDevelopersMessage = Environment.GetEnvironmentVariable("SLACK_LATE_DEVELOPERS_MESSAGE").Replace(@"\n", "\n"),
-                    NoLateDevelopersMessage = Environment.GetEnvironmentVariable("SLACK_NO_LATE_DEVELOPERS_MESSAGE"),
+                    LateBillablePeopleMessage = Environment.GetEnvironmentVariable("SLACK_LATE_DEVELOPERS_MESSAGE").Replace(@"\n", "\n"),
+                    NoLateBillablePeopleMessage = Environment.GetEnvironmentVariable("SLACK_NO_LATE_DEVELOPERS_MESSAGE"),
                     Channel = Environment.GetEnvironmentVariable("SLACK_CHANNEL_ID")
                 }
             );

--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -15,7 +15,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
         private const string Token = "xxxx-xxxxxxxxx-xxxx";
         private const string HarvestAccountId = "123456";
         private const string UserAgent = "The Wolves";
-        private const string DeveloperRoles = 
+        private const string BillablePersonRoles = 
             @"Software Engineer, Senior Software Engineer, Senior Engineer, Lead Engineer, 
             Delivery Manager, SRE, Consultant, Delivery Principal";
         
@@ -29,7 +29,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             public void Setup()
             {
                 _harvestApi = new FluentSimulator(Address);
-                _harvestGateway = new HarvestGateway(Address, Token, HarvestAccountId, UserAgent, DeveloperRoles);
+                _harvestGateway = new HarvestGateway(Address, Token, HarvestAccountId, UserAgent, BillablePersonRoles);
                 
                 var json = File.ReadAllText(
                     Path.Combine(
@@ -82,7 +82,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             public void CanGetWeeklyHoursForBillablePeople(string name, int hours)
             {
                 var response = _harvestGateway.RetrieveBillablePeople();   
-                response.First(developer => developer.FirstName == name).WeeklyHours.Should().Be(hours);
+                response.First(billablePerson => billablePerson.FirstName == name).WeeklyHours.Should().Be(hours);
             }
         }
 
@@ -97,7 +97,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             public void Setup()
             {
                 _harvestApi = new FluentSimulator(Address);
-                _harvestGateway = new HarvestGateway(Address, Token, HarvestAccountId, UserAgent, DeveloperRoles);
+                _harvestGateway = new HarvestGateway(Address, Token, HarvestAccountId, UserAgent, BillablePersonRoles);
                 _defaultDateFrom = new DateTimeOffset(
                     new DateTime(2019, 04, 08)
                 );

--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -23,7 +23,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
         private static HarvestGateway _harvestGateway;
         
         [TestFixture]
-        public class CanRequestDevelopers
+        public class CanRequestBillablePeople
         {
             [SetUp]
             public void Setup()
@@ -51,7 +51,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             [Test]
             public void CanSendOneRequestAtATime()
             {
-                _harvestGateway.RetrieveDevelopers();
+                _harvestGateway.RetrieveBillablePeople();
                
                 _harvestApi.ReceivedRequests.Count.Should().Be(1);
             }
@@ -60,17 +60,17 @@ namespace CryptoTechReminderSystem.Test.Gateway
             [TestCase("Authorization", "Bearer " + Token)]
             [TestCase("Harvest-Account-Id", HarvestAccountId)]
             [TestCase("User-Agent", UserAgent)]
-            public void CanGetDevelopersWithHeaders(string header, string expected)
+            public void CanGetBillablePeopleWithHeaders(string header, string expected)
             {
-                _harvestGateway.RetrieveDevelopers();
+                _harvestGateway.RetrieveBillablePeople();
                 
                 _harvestApi.ReceivedRequests.First().Headers[header].Should().Be(expected);
             }
             
             [Test]
-            public void CanOnlyGetActiveDevelopers()
+            public void CanOnlyGetActiveBillablePeople()
             {
-                var response = _harvestGateway.RetrieveDevelopers();
+                var response = _harvestGateway.RetrieveBillablePeople();
                 
                 response.First().FirstName.Should().Be("Dick");
                 response.Count.Should().Be(7);
@@ -79,9 +79,9 @@ namespace CryptoTechReminderSystem.Test.Gateway
             [Test]
             [TestCase("Alfred", 35)]
             [TestCase("Harvey", 28)]
-            public void CanGetWeeklyHoursForDevelopers(string name, int hours)
+            public void CanGetWeeklyHoursForBillablePeople(string name, int hours)
             {
-                var response = _harvestGateway.RetrieveDevelopers();   
+                var response = _harvestGateway.RetrieveBillablePeople();   
                 response.First(developer => developer.FirstName == name).WeeklyHours.Should().Be(hours);
             }
         }

--- a/CryptoTechReminderSystem.Test/Gateway/SlackGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/SlackGatewayTests.cs
@@ -194,7 +194,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
         }
 
         [TestFixture]
-        public class CanRetrieveDevelopers
+        public class CanRetrieveBillablePeople
         {
             private FluentSimulator _slackApi;
             private SlackGateway _slackGateway;
@@ -217,7 +217,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             
                 _slackApi.Start();
 
-                _response = _slackGateway.RetrieveDevelopers();
+                _response = _slackGateway.RetrieveBillablePeople();
             }
             
             [TearDown]
@@ -243,7 +243,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             }
         
             [Test]
-            public void CanGetAListOfSlackDevelopers()
+            public void CanGetAListOfSlackBillablePeople()
             {
                 _response.Should().BeOfType<List<SlackDeveloper>>();
                 _response.Should().HaveCount(6);
@@ -286,7 +286,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             
                 _slackApi.Start();
 
-                _response = _slackGateway.RetrieveDevelopers();
+                _response = _slackGateway.RetrieveBillablePeople();
             }
             
             [TearDown]
@@ -312,7 +312,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             }
         
             [Test]
-            public void CanGetAListOfSlackDevelopers()
+            public void CanGetAListOfSlackBillablePeople()
             {
                 _response.Should().BeOfType<List<SlackDeveloper>>();
                 _response.Should().HaveCount(2);

--- a/CryptoTechReminderSystem.Test/Gateway/SlackGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/SlackGatewayTests.cs
@@ -198,7 +198,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
         {
             private FluentSimulator _slackApi;
             private SlackGateway _slackGateway;
-            private IList<SlackDeveloper> _response;
+            private IList<SlackBillablePerson> _response;
 
             [SetUp]
             public void SetUp()
@@ -245,18 +245,18 @@ namespace CryptoTechReminderSystem.Test.Gateway
             [Test]
             public void CanGetAListOfSlackBillablePeople()
             {
-                _response.Should().BeOfType<List<SlackDeveloper>>();
+                _response.Should().BeOfType<List<SlackBillablePerson>>();
                 _response.Should().HaveCount(6);
             }
         
             [Test]
-            public void CanGetIdOfSlackDeveloper()
+            public void CanGetIdOfSlackBillablePerson()
             {
                 _response.First().Id.Should().Be("W0123CHAN");
             }
             
             [Test]
-            public void CanGetEmailOfSlackDeveloper()
+            public void CanGetEmailOfSlackBillablePerson()
             {
                 _response.First().Email.Should().Be("chandler@friends.com");
             }
@@ -267,7 +267,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
         {
             private FluentSimulator _slackApi;
             private SlackGateway _slackGateway;
-            private IList<SlackDeveloper> _response;
+            private IList<SlackBillablePerson> _response;
 
             [SetUp]
             public void SetUp()
@@ -314,18 +314,18 @@ namespace CryptoTechReminderSystem.Test.Gateway
             [Test]
             public void CanGetAListOfSlackBillablePeople()
             {
-                _response.Should().BeOfType<List<SlackDeveloper>>();
+                _response.Should().BeOfType<List<SlackBillablePerson>>();
                 _response.Should().HaveCount(2);
             }
         
             [Test]
-            public void CanGetIdOfSlackDeveloper()
+            public void CanGetIdOfSlackBillablePerson()
             {
                 _response.First().Id.Should().Be("W345JOEY");
             }
             
             [Test]
-            public void CanGetEmailOfSlackDeveloper()
+            public void CanGetEmailOfSlackBillablePerson()
             {
                 _response.First().Email.Should().Be("joey@friends.com");
             }

--- a/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersEmptyStub.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersEmptyStub.cs
@@ -10,7 +10,7 @@ namespace CryptoTechReminderSystem.Test.TestDouble
         {
             return new GetLateBillablePeopleResponse
             {
-                BillablePeople = new List<GetLateBillablePeopleResponse.LateDeveloper>()
+                BillablePeople = new List<GetLateBillablePeopleResponse.LateBillablePerson>()
             };
         }
     }

--- a/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersEmptyStub.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersEmptyStub.cs
@@ -10,7 +10,7 @@ namespace CryptoTechReminderSystem.Test.TestDouble
         {
             return new GetLateBillablePeopleResponse
             {
-                Developers = new List<GetLateBillablePeopleResponse.LateDeveloper>()
+                BillablePeople = new List<GetLateBillablePeopleResponse.LateDeveloper>()
             };
         }
     }

--- a/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersEmptyStub.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersEmptyStub.cs
@@ -4,13 +4,13 @@ using CryptoTechReminderSystem.UseCase;
 
 namespace CryptoTechReminderSystem.Test.TestDouble
 {
-    public class GetLateDevelopersEmptyStub : IGetLateDevelopers
+    public class GetLateBillablePeopleEmptyStub : IGetLateBillablePeople
     {
-        public GetLateDevelopersResponse Execute()
+        public GetLateBillablePeopleResponse Execute()
         {
-            return new GetLateDevelopersResponse
+            return new GetLateBillablePeopleResponse
             {
-                Developers = new List<GetLateDevelopersResponse.LateDeveloper>()
+                Developers = new List<GetLateBillablePeopleResponse.LateDeveloper>()
             };
         }
     }

--- a/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersSpy.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersSpy.cs
@@ -4,19 +4,19 @@ using CryptoTechReminderSystem.UseCase;
 
 namespace CryptoTechReminderSystem.Test.TestDouble
 {
-    public class GetLateDevelopersSpy : IGetLateDevelopers
+    public class GetLateBillablePeopleSpy : IGetLateBillablePeople
     {
         public bool Called { private set; get; }
 
-        public GetLateDevelopersResponse Execute()
+        public GetLateBillablePeopleResponse Execute()
         {
             Called = true;
             
-            return new GetLateDevelopersResponse
+            return new GetLateBillablePeopleResponse
             {
-                Developers = new List<GetLateDevelopersResponse.LateDeveloper>
+                Developers = new List<GetLateBillablePeopleResponse.LateDeveloper>
                 {
-                    new GetLateDevelopersResponse.LateDeveloper()
+                    new GetLateBillablePeopleResponse.LateDeveloper()
                     {
                         Id = "U9034950",
                         Email = "UncleCraig@aol.com"

--- a/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersSpy.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersSpy.cs
@@ -14,7 +14,7 @@ namespace CryptoTechReminderSystem.Test.TestDouble
             
             return new GetLateBillablePeopleResponse
             {
-                Developers = new List<GetLateBillablePeopleResponse.LateDeveloper>
+                BillablePeople = new List<GetLateBillablePeopleResponse.LateDeveloper>
                 {
                     new GetLateBillablePeopleResponse.LateDeveloper()
                     {

--- a/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersSpy.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersSpy.cs
@@ -14,9 +14,9 @@ namespace CryptoTechReminderSystem.Test.TestDouble
             
             return new GetLateBillablePeopleResponse
             {
-                BillablePeople = new List<GetLateBillablePeopleResponse.LateDeveloper>
+                BillablePeople = new List<GetLateBillablePeopleResponse.LateBillablePerson>
                 {
-                    new GetLateBillablePeopleResponse.LateDeveloper()
+                    new GetLateBillablePeopleResponse.LateBillablePerson()
                     {
                         Id = "U9034950",
                         Email = "UncleCraig@aol.com"

--- a/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersStub.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersStub.cs
@@ -44,7 +44,7 @@ namespace CryptoTechReminderSystem.Test.TestDouble
         {
             return new GetLateBillablePeopleResponse
             {
-                Developers = _lateBillablePeople
+                BillablePeople = _lateBillablePeople
             };
         }
     }

--- a/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersStub.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersStub.cs
@@ -6,19 +6,19 @@ namespace CryptoTechReminderSystem.Test.TestDouble
 {
     public class GetLateBillablePeopleStub : IGetLateBillablePeople
     {
-        private readonly List<GetLateBillablePeopleResponse.LateDeveloper> _lateBillablePeople;
+        private readonly List<GetLateBillablePeopleResponse.LateBillablePerson> _lateBillablePeople;
 
-        private static List<GetLateBillablePeopleResponse.LateDeveloper> DefaultList => new List<GetLateBillablePeopleResponse.LateDeveloper>
+        private static List<GetLateBillablePeopleResponse.LateBillablePerson> DefaultList => new List<GetLateBillablePeopleResponse.LateBillablePerson>
         {
-            new GetLateBillablePeopleResponse.LateDeveloper
+            new GetLateBillablePeopleResponse.LateBillablePerson
                 {
                     Id = "W0123CHAN"
                 },
-            new GetLateBillablePeopleResponse.LateDeveloper
+            new GetLateBillablePeopleResponse.LateBillablePerson
                 {
                     Id = "W123AMON"
                 },
-            new GetLateBillablePeopleResponse.LateDeveloper
+            new GetLateBillablePeopleResponse.LateBillablePerson
                 {
                     Id = "W789ROSS"
                 }
@@ -26,18 +26,18 @@ namespace CryptoTechReminderSystem.Test.TestDouble
         
         public GetLateBillablePeopleStub(List<string> lateBillablePeople = null)
         {
-            var templateDeveloper = new List<GetLateBillablePeopleResponse.LateDeveloper>();
+            var templateBillablePerson = new List<GetLateBillablePeopleResponse.LateBillablePerson>();
 
             if (lateBillablePeople != null)
-                foreach (var developer in lateBillablePeople)
+                foreach (var billablePerson in lateBillablePeople)
                 {
-                    templateDeveloper.Add(new GetLateBillablePeopleResponse.LateDeveloper
+                    templateBillablePerson.Add(new GetLateBillablePeopleResponse.LateBillablePerson
                     {
-                        Id = developer
+                        Id = billablePerson
                     });
                 }
 
-            _lateBillablePeople = templateDeveloper.Count == 0 ? DefaultList : templateDeveloper;
+            _lateBillablePeople = templateBillablePerson.Count == 0 ? DefaultList : templateBillablePerson;
         }
         
         public GetLateBillablePeopleResponse Execute()

--- a/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersStub.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/GetLateDevelopersStub.cs
@@ -4,47 +4,47 @@ using CryptoTechReminderSystem.UseCase;
 
 namespace CryptoTechReminderSystem.Test.TestDouble
 {
-    public class GetLateDevelopersStub : IGetLateDevelopers
+    public class GetLateBillablePeopleStub : IGetLateBillablePeople
     {
-        private readonly List<GetLateDevelopersResponse.LateDeveloper> _lateDevelopers;
+        private readonly List<GetLateBillablePeopleResponse.LateDeveloper> _lateBillablePeople;
 
-        private static List<GetLateDevelopersResponse.LateDeveloper> DefaultList => new List<GetLateDevelopersResponse.LateDeveloper>
+        private static List<GetLateBillablePeopleResponse.LateDeveloper> DefaultList => new List<GetLateBillablePeopleResponse.LateDeveloper>
         {
-            new GetLateDevelopersResponse.LateDeveloper
+            new GetLateBillablePeopleResponse.LateDeveloper
                 {
                     Id = "W0123CHAN"
                 },
-            new GetLateDevelopersResponse.LateDeveloper
+            new GetLateBillablePeopleResponse.LateDeveloper
                 {
                     Id = "W123AMON"
                 },
-            new GetLateDevelopersResponse.LateDeveloper
+            new GetLateBillablePeopleResponse.LateDeveloper
                 {
                     Id = "W789ROSS"
                 }
         };
         
-        public GetLateDevelopersStub(List<string> lateDevelopers = null)
+        public GetLateBillablePeopleStub(List<string> lateBillablePeople = null)
         {
-            var templateDeveloper = new List<GetLateDevelopersResponse.LateDeveloper>();
+            var templateDeveloper = new List<GetLateBillablePeopleResponse.LateDeveloper>();
 
-            if (lateDevelopers != null)
-                foreach (var developer in lateDevelopers)
+            if (lateBillablePeople != null)
+                foreach (var developer in lateBillablePeople)
                 {
-                    templateDeveloper.Add(new GetLateDevelopersResponse.LateDeveloper
+                    templateDeveloper.Add(new GetLateBillablePeopleResponse.LateDeveloper
                     {
                         Id = developer
                     });
                 }
 
-            _lateDevelopers = templateDeveloper.Count == 0 ? DefaultList : templateDeveloper;
+            _lateBillablePeople = templateDeveloper.Count == 0 ? DefaultList : templateDeveloper;
         }
         
-        public GetLateDevelopersResponse Execute()
+        public GetLateBillablePeopleResponse Execute()
         {
-            return new GetLateDevelopersResponse
+            return new GetLateBillablePeopleResponse
             {
-                Developers = _lateDevelopers
+                Developers = _lateBillablePeople
             };
         }
     }

--- a/CryptoTechReminderSystem.Test/TestDouble/HarvestGatewaySpy.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/HarvestGatewaySpy.cs
@@ -5,17 +5,17 @@ using CryptoTechReminderSystem.Gateway;
 
 namespace CryptoTechReminderSystem.Test.TestDouble
 {
-    public class HarvestGatewaySpy : IHarvestDeveloperRetriever, ITimeSheetRetriever
+    public class HarvestGatewaySpy : IHarvestBillablePersonRetriever, ITimeSheetRetriever
     {
         public bool IsRetrieveBillablePeopleCalled;
         public bool IsRetrieveTimeSheetsCalled;
         public DateTimeOffset[] RetrieveTimeSheetsArguments;
             
-        public IList<HarvestDeveloper> RetrieveBillablePeople()
+        public IList<HarvestBillablePerson> RetrieveBillablePeople()
         {
             IsRetrieveBillablePeopleCalled = true;
               
-            return new List<HarvestDeveloper>();
+            return new List<HarvestBillablePerson>();
         }
 
         public IList<TimeSheet> RetrieveTimeSheets(DateTimeOffset dateFrom, DateTimeOffset dateTo)

--- a/CryptoTechReminderSystem.Test/TestDouble/HarvestGatewaySpy.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/HarvestGatewaySpy.cs
@@ -7,13 +7,13 @@ namespace CryptoTechReminderSystem.Test.TestDouble
 {
     public class HarvestGatewaySpy : IHarvestDeveloperRetriever, ITimeSheetRetriever
     {
-        public bool IsRetrieveDevelopersCalled;
+        public bool IsRetrieveBillablePeopleCalled;
         public bool IsRetrieveTimeSheetsCalled;
         public DateTimeOffset[] RetrieveTimeSheetsArguments;
             
-        public IList<HarvestDeveloper> RetrieveDevelopers()
+        public IList<HarvestDeveloper> RetrieveBillablePeople()
         {
-            IsRetrieveDevelopersCalled = true;
+            IsRetrieveBillablePeopleCalled = true;
               
             return new List<HarvestDeveloper>();
         }

--- a/CryptoTechReminderSystem.Test/TestDouble/HarvestGatewayStub.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/HarvestGatewayStub.cs
@@ -7,13 +7,13 @@ namespace CryptoTechReminderSystem.Test.TestDouble
 {
     public class HarvestGatewayStub : IHarvestDeveloperRetriever, ITimeSheetRetriever
     {
-        public HarvestDeveloper[] Developers { private get; set; }
+        public HarvestDeveloper[] BillablePeople { private get; set; }
             
         public TimeSheet[] TimeSheets { private get; set; }
             
-        public IList<HarvestDeveloper> RetrieveDevelopers()
+        public IList<HarvestDeveloper> RetrieveBillablePeople()
         {
-            return Developers;
+            return BillablePeople;
         }
 
         public IList<TimeSheet> RetrieveTimeSheets(DateTimeOffset dateFrom, DateTimeOffset dateTo)

--- a/CryptoTechReminderSystem.Test/TestDouble/HarvestGatewayStub.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/HarvestGatewayStub.cs
@@ -5,13 +5,13 @@ using CryptoTechReminderSystem.Gateway;
 
 namespace CryptoTechReminderSystem.Test.TestDouble
 {
-    public class HarvestGatewayStub : IHarvestDeveloperRetriever, ITimeSheetRetriever
+    public class HarvestGatewayStub : IHarvestBillablePersonRetriever, ITimeSheetRetriever
     {
-        public HarvestDeveloper[] BillablePeople { private get; set; }
+        public HarvestBillablePerson[] BillablePeople { private get; set; }
             
         public TimeSheet[] TimeSheets { private get; set; }
             
-        public IList<HarvestDeveloper> RetrieveBillablePeople()
+        public IList<HarvestBillablePerson> RetrieveBillablePeople()
         {
             return BillablePeople;
         }

--- a/CryptoTechReminderSystem.Test/TestDouble/SlackGatewaySpy.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/SlackGatewaySpy.cs
@@ -4,15 +4,15 @@ using CryptoTechReminderSystem.Gateway;
 
 namespace CryptoTechReminderSystem.Test.TestDouble
 {
-    public class SlackGatewaySpy : ISlackDeveloperRetriever
+    public class SlackGatewaySpy : ISlackBillablePersonRetriever
     {
         public bool IsRetrieveBillablePeopleCalled;
 
-        public IList<SlackDeveloper> RetrieveBillablePeople()
+        public IList<SlackBillablePerson> RetrieveBillablePeople()
         {
             IsRetrieveBillablePeopleCalled = true;
                 
-            return new List<SlackDeveloper>();
+            return new List<SlackBillablePerson>();
         }
     }
 }

--- a/CryptoTechReminderSystem.Test/TestDouble/SlackGatewaySpy.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/SlackGatewaySpy.cs
@@ -6,11 +6,11 @@ namespace CryptoTechReminderSystem.Test.TestDouble
 {
     public class SlackGatewaySpy : ISlackDeveloperRetriever
     {
-        public bool IsRetrieveDevelopersCalled;
+        public bool IsRetrieveBillablePeopleCalled;
 
-        public IList<SlackDeveloper> RetrieveDevelopers()
+        public IList<SlackDeveloper> RetrieveBillablePeople()
         {
-            IsRetrieveDevelopersCalled = true;
+            IsRetrieveBillablePeopleCalled = true;
                 
             return new List<SlackDeveloper>();
         }

--- a/CryptoTechReminderSystem.Test/TestDouble/SlackGatewayStub.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/SlackGatewayStub.cs
@@ -6,11 +6,11 @@ namespace CryptoTechReminderSystem.Test.TestDouble
 {
     public class SlackGatewayStub : ISlackDeveloperRetriever
     {
-        public SlackDeveloper[] Developers;
+        public SlackDeveloper[] BillablePeople;
 
-        public IList<SlackDeveloper> RetrieveDevelopers()
+        public IList<SlackDeveloper> RetrieveBillablePeople()
         {
-            return Developers;
+            return BillablePeople;
         }
     }
 }

--- a/CryptoTechReminderSystem.Test/TestDouble/SlackGatewayStub.cs
+++ b/CryptoTechReminderSystem.Test/TestDouble/SlackGatewayStub.cs
@@ -4,11 +4,11 @@ using CryptoTechReminderSystem.Gateway;
 
 namespace CryptoTechReminderSystem.Test.TestDouble
 {
-    public class SlackGatewayStub : ISlackDeveloperRetriever
+    public class SlackGatewayStub : ISlackBillablePersonRetriever
     {
-        public SlackDeveloper[] BillablePeople;
+        public SlackBillablePerson[] BillablePeople;
 
-        public IList<SlackDeveloper> RetrieveBillablePeople()
+        public IList<SlackBillablePerson> RetrieveBillablePeople()
         {
             return BillablePeople;
         }

--- a/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
@@ -146,7 +146,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 {
                     BillablePeople = new[]
                     {
-                        new HarvestDeveloper
+                        new HarvestBillablePerson
                         {   
                             Id = 1337,
                             FirstName = "Fred",
@@ -154,7 +154,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                             Email = "fred@fred.com",
                             WeeklyHours = 35
                         },
-                        new HarvestDeveloper
+                        new HarvestBillablePerson
                         {
                             Id = 123,
                             FirstName = "Joe",
@@ -169,12 +169,12 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 {
                     BillablePeople = new[]
                     {
-                        new SlackDeveloper
+                        new SlackBillablePerson
                         {
                             Email = "fred@fred.com",
                             Id = "U8723"
                         }, 
-                        new SlackDeveloper
+                        new SlackBillablePerson
                         {
                             Email = "Joe@Bloggs.com",
                             Id = "U9999"
@@ -186,7 +186,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
             [Test]
             [TestCase(1337, 5, "U8723", "U9999")]
             [TestCase(123, 4,"U9999", "U8723")]
-            public void CanGetLateADeveloper(int harvestUserId, int capacityInDays,string submittingUserSlackUserId, string lateUsersSlackUserId)
+            public void CanGetLateABillablePerson(int harvestUserId, int capacityInDays,string submittingUserSlackUserId, string lateUsersSlackUserId)
             {
                 _harvestGatewayStub.TimeSheets = Enumerable.Repeat(
                     new TimeSheet { Hours = 7, UserId = harvestUserId }, capacityInDays
@@ -200,14 +200,14 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 var getLateBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
                 var response = getLateBillablePeople.Execute();
                 
-                response.BillablePeople.Any(developer => developer.Id == lateUsersSlackUserId).Should().BeTrue();
-                response.BillablePeople.Any(developer => developer.Id == submittingUserSlackUserId).Should().BeFalse();
+                response.BillablePeople.Any(billablePerson => billablePerson.Id == lateUsersSlackUserId).Should().BeTrue();
+                response.BillablePeople.Any(billablePerson => billablePerson.Id == submittingUserSlackUserId).Should().BeFalse();
             }
             
             [Test]
             [TestCase(1337, 0, "U8723", "U9999")]
             [TestCase(123, 1, "U9999", "U8723")]
-            public void CanGetLateADeveloperMidweek(int harvestUserId, int nonWorkedWeekDayForPartTime, string submittingUserSlackUserId, string lateUsersSlackUserId)
+            public void CanGetLateABillablePersonMidweek(int harvestUserId, int nonWorkedWeekDayForPartTime, string submittingUserSlackUserId, string lateUsersSlackUserId)
             {
                 var clock = new ClockStub(
                     new DateTimeOffset(
@@ -225,8 +225,8 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 var getLateBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
                 var response = getLateBillablePeople.Execute();
                 
-                response.BillablePeople.Should().Contain(developer => developer.Id == lateUsersSlackUserId);
-                response.BillablePeople.Should().NotContain(developer => developer.Id == submittingUserSlackUserId);
+                response.BillablePeople.Should().Contain(billablePerson => billablePerson.Id == lateUsersSlackUserId);
+                response.BillablePeople.Should().NotContain(billablePerson => billablePerson.Id == submittingUserSlackUserId);
             }
             
             [Test]
@@ -269,7 +269,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 {
                     BillablePeople = new[]
                     {
-                        new HarvestDeveloper
+                        new HarvestBillablePerson
                         {   
                             Id = 1337,
                             FirstName = "Fred",
@@ -277,7 +277,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                             Email = "fred@fred.com",
                             WeeklyHours = 35
                         },
-                        new HarvestDeveloper
+                        new HarvestBillablePerson
                         {
                             Id = 123,
                             FirstName = "Joe",
@@ -285,7 +285,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                             Email = "Joe@Bloggs.com",
                             WeeklyHours = 35
                         },
-                        new HarvestDeveloper
+                        new HarvestBillablePerson
                         {
                             Id = 101,
                             FirstName = "Jimbob",
@@ -300,12 +300,12 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 {
                     BillablePeople = new[]
                     {
-                        new SlackDeveloper
+                        new SlackBillablePerson
                         {
                             Email = "fred@fred.com",
                             Id = "U8723"
                         }, 
-                        new SlackDeveloper
+                        new SlackBillablePerson
                         {
                             Email = "Joe@Bloggs.com",
                             Id = "U9999"
@@ -315,7 +315,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
             }
             
             [Test]
-            public void CanHandleWhenCannotFindMatchingSlackDeveloper()
+            public void CanHandleWhenCannotFindMatchingSlackBillablePerson()
             {
                 _harvestGatewayStub.TimeSheets = Enumerable.Repeat(
                     new TimeSheet { Hours = 7, UserId = 123 }, 5
@@ -334,7 +334,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 {
                     BillablePeople = new[]
                     {
-                        new HarvestDeveloper
+                        new HarvestBillablePerson
                         {
                             Id = 101,
                             FirstName = "Jimbob",
@@ -349,12 +349,12 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 {
                     BillablePeople = new[]
                     {
-                        new SlackDeveloper
+                        new SlackBillablePerson
                         {
                             Email = "fred@fred.com",
                             Id = "U8723"
                         }, 
-                        new SlackDeveloper
+                        new SlackBillablePerson
                         {
                             Email = "Joe@Bloggs.com",
                             Id = "U9999"
@@ -379,7 +379,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 {
                     BillablePeople = new[]
                     {
-                        new HarvestDeveloper
+                        new HarvestBillablePerson
                         {
                             Id = 101,
                             FirstName = "Fred",
@@ -394,12 +394,12 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 {
                     BillablePeople = new[]
                     {
-                        new SlackDeveloper
+                        new SlackBillablePerson
                         {
                             Email = "freddy@aol.co.uk",
                             Id = "U8723"
                         }, 
-                        new SlackDeveloper
+                        new SlackBillablePerson
                         {
                             Email = "Joe@Bloggs.com",
                             Id = "U9999"
@@ -426,7 +426,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 {
                     BillablePeople = new[]
                     {
-                        new HarvestDeveloper
+                        new HarvestBillablePerson
                         {
                             Id = 101,
                             FirstName = "Fred",
@@ -441,12 +441,12 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 {
                     BillablePeople = new[]
                     {
-                        new SlackDeveloper
+                        new SlackBillablePerson
                         {
                             Email = "Freddy@Aol.com",
                             Id = "U8723"
                         }, 
-                        new SlackDeveloper
+                        new SlackBillablePerson
                         {
                             Email = "Joe@Bloggs.com",
                             Id = "U9999"

--- a/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 
 namespace CryptoTechReminderSystem.Test.UseCase
 {
-    public class GetLateDevelopersTests
+    public class GetLateBillablePeopleTests
     {
         private static HarvestGatewaySpy _harvestGatewaySpy;
         private static SlackGatewaySpy _slackGatewaySpy;
@@ -24,7 +24,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
         public class CanGetDevelopers
         {
             private ClockStub _clock;
-            private GetLateDevelopers _getDevelopers;
+            private GetLateBillablePeople _getDevelopers;
             
             [SetUp]
             public void SetUp()
@@ -37,7 +37,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     )
                 );
 
-                _getDevelopers = new GetLateDevelopers(_slackGatewaySpy, _harvestGatewaySpy, _harvestGatewaySpy, _clock);
+                _getDevelopers = new GetLateBillablePeople(_slackGatewaySpy, _harvestGatewaySpy, _harvestGatewaySpy, _clock);
             }
             
             [Test]
@@ -77,7 +77,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                         new DateTime(2019, 03, 01, 10, 30, 0)
                     )
                 );
-                var getDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
+                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
             
                 getDevelopers.Execute();
 
@@ -97,7 +97,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                         new DateTime(2019, 04, day)
                     )
                 );
-                var getDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
+                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
             
                 getDevelopers.Execute();
 
@@ -121,7 +121,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                         new DateTime(2019, 04, day)
                     )
                 );
-                var getDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
+                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
             
                 getDevelopers.Execute();
 
@@ -134,7 +134,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
         }
         
         [TestFixture]
-        public class CanGetLateDevelopers
+        public class CanGetLateBillablePeople
         {
             private HarvestGatewayStub _harvestGatewayStub;
             private SlackGatewayStub _slackGatewayStub;
@@ -197,8 +197,8 @@ namespace CryptoTechReminderSystem.Test.UseCase
                         new DateTime(2019, 03, 01, 10, 30, 0)
                     )
                 );
-                var getLateDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
-                var response = getLateDevelopers.Execute();
+                var getLateBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
+                var response = getLateBillablePeople.Execute();
                 
                 response.Developers.Any(developer => developer.Id == lateUsersSlackUserId).Should().BeTrue();
                 response.Developers.Any(developer => developer.Id == submittingUserSlackUserId).Should().BeFalse();
@@ -222,15 +222,15 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     new TimeSheet { Hours = 7, UserId = harvestUserId }, expectedDays
                 ).ToArray();
                 
-                var getLateDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
-                var response = getLateDevelopers.Execute();
+                var getLateBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
+                var response = getLateBillablePeople.Execute();
                 
                 response.Developers.Should().Contain(developer => developer.Id == lateUsersSlackUserId);
                 response.Developers.Should().NotContain(developer => developer.Id == submittingUserSlackUserId);
             }
             
             [Test]
-            public void CanNotGetLateDevelopersOnWeekend()
+            public void CanNotGetLateBillablePeopleOnWeekend()
             {
                 _harvestGatewayStub.TimeSheets = Enumerable.Repeat(
                     new TimeSheet { Hours = 7, UserId = 000 }, 2
@@ -242,8 +242,8 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     )
                 );
                 
-                var getLateDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
-                var response = getLateDevelopers.Execute();
+                var getLateBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
+                var response = getLateBillablePeople.Execute();
 
                 response.Developers.Should().HaveCount(0);
             }
@@ -321,7 +321,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     new TimeSheet { Hours = 7, UserId = 123 }, 5
                 ).ToArray();
                 
-                var getDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
+                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
                 var response = getDevelopers.Execute();
 
                 response.Developers.First().Id.Should().Be("U8723");
@@ -366,7 +366,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     new TimeSheet { Hours = 0, UserId = 444 }, 5
                 ).ToArray();
                 
-                var getDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
+                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
                 var response = getDevelopers.Execute();
                 
                 response.Developers.Count.Should().Be(0);
@@ -411,7 +411,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     new TimeSheet { Hours = 0, UserId = 444 }, 5
                 ).ToArray();
                 
-                var getDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
+                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
                 var response = getDevelopers.Execute();
                 
                 response.Developers.Count.Should().Be(1);
@@ -458,7 +458,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     new TimeSheet { Hours = 0, UserId = 444 }, 5
                 ).ToArray();
                 
-                var getDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
+                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
                 var response = getDevelopers.Execute();
                 
                 response.Developers.Count.Should().Be(1);

--- a/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
@@ -21,10 +21,10 @@ namespace CryptoTechReminderSystem.Test.UseCase
         }
         
         [TestFixture]
-        public class CanGetDevelopers
+        public class CanGetBillablePeople
         {
             private ClockStub _clock;
-            private GetLateBillablePeople _getDevelopers;
+            private GetLateBillablePeople _getBillablePeople;
             
             [SetUp]
             public void SetUp()
@@ -37,23 +37,23 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     )
                 );
 
-                _getDevelopers = new GetLateBillablePeople(_slackGatewaySpy, _harvestGatewaySpy, _harvestGatewaySpy, _clock);
+                _getBillablePeople = new GetLateBillablePeople(_slackGatewaySpy, _harvestGatewaySpy, _harvestGatewaySpy, _clock);
             }
             
             [Test]
-            public void CanGetHarvestDevelopers()
+            public void CanGetHarvestBillablePeople()
             {
-                _getDevelopers.Execute();
+                _getBillablePeople.Execute();
 
-                _harvestGatewaySpy.IsRetrieveDevelopersCalled.Should().BeTrue();
+                _harvestGatewaySpy.IsRetrieveBillablePeopleCalled.Should().BeTrue();
             }
 
             [Test]
-            public void CanGetSlackDevelopers()
+            public void CanGetSlackBillablePeople()
             {
-                _getDevelopers.Execute();
+                _getBillablePeople.Execute();
 
-                _slackGatewaySpy.IsRetrieveDevelopersCalled.Should().BeTrue();
+                _slackGatewaySpy.IsRetrieveBillablePeopleCalled.Should().BeTrue();
             }
         }
 
@@ -77,9 +77,9 @@ namespace CryptoTechReminderSystem.Test.UseCase
                         new DateTime(2019, 03, 01, 10, 30, 0)
                     )
                 );
-                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
+                var getBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
             
-                getDevelopers.Execute();
+                getBillablePeople.Execute();
 
                 _harvestGatewaySpy.IsRetrieveTimeSheetsCalled.Should().BeTrue();
             }
@@ -97,9 +97,9 @@ namespace CryptoTechReminderSystem.Test.UseCase
                         new DateTime(2019, 04, day)
                     )
                 );
-                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
+                var getBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
             
-                getDevelopers.Execute();
+                getBillablePeople.Execute();
 
                 _harvestGatewaySpy.RetrieveTimeSheetsArguments[0].Should().Be(
                     new DateTimeOffset(
@@ -121,9 +121,9 @@ namespace CryptoTechReminderSystem.Test.UseCase
                         new DateTime(2019, 04, day)
                     )
                 );
-                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
+                var getBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
             
-                getDevelopers.Execute();
+                getBillablePeople.Execute();
 
                 _harvestGatewaySpy.RetrieveTimeSheetsArguments[1].Should().Be(
                     new DateTimeOffset(
@@ -144,7 +144,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
             {
                 _harvestGatewayStub = new HarvestGatewayStub
                 {
-                    Developers = new[]
+                    BillablePeople = new[]
                     {
                         new HarvestDeveloper
                         {   
@@ -167,7 +167,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 
                 _slackGatewayStub = new SlackGatewayStub
                 {
-                    Developers = new[]
+                    BillablePeople = new[]
                     {
                         new SlackDeveloper
                         {
@@ -200,8 +200,8 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 var getLateBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
                 var response = getLateBillablePeople.Execute();
                 
-                response.Developers.Any(developer => developer.Id == lateUsersSlackUserId).Should().BeTrue();
-                response.Developers.Any(developer => developer.Id == submittingUserSlackUserId).Should().BeFalse();
+                response.BillablePeople.Any(developer => developer.Id == lateUsersSlackUserId).Should().BeTrue();
+                response.BillablePeople.Any(developer => developer.Id == submittingUserSlackUserId).Should().BeFalse();
             }
             
             [Test]
@@ -225,8 +225,8 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 var getLateBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
                 var response = getLateBillablePeople.Execute();
                 
-                response.Developers.Should().Contain(developer => developer.Id == lateUsersSlackUserId);
-                response.Developers.Should().NotContain(developer => developer.Id == submittingUserSlackUserId);
+                response.BillablePeople.Should().Contain(developer => developer.Id == lateUsersSlackUserId);
+                response.BillablePeople.Should().NotContain(developer => developer.Id == submittingUserSlackUserId);
             }
             
             [Test]
@@ -245,7 +245,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 var getLateBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
                 var response = getLateBillablePeople.Execute();
 
-                response.Developers.Should().HaveCount(0);
+                response.BillablePeople.Should().HaveCount(0);
             }
         } 
 
@@ -267,7 +267,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 
                 _harvestGatewayStub = new HarvestGatewayStub
                 {
-                    Developers = new[]
+                    BillablePeople = new[]
                     {
                         new HarvestDeveloper
                         {   
@@ -298,7 +298,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 
                 _slackGatewayStub = new SlackGatewayStub
                 {
-                    Developers = new[]
+                    BillablePeople = new[]
                     {
                         new SlackDeveloper
                         {
@@ -321,10 +321,10 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     new TimeSheet { Hours = 7, UserId = 123 }, 5
                 ).ToArray();
                 
-                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
-                var response = getDevelopers.Execute();
+                var getBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
+                var response = getBillablePeople.Execute();
 
-                response.Developers.First().Id.Should().Be("U8723");
+                response.BillablePeople.First().Id.Should().Be("U8723");
             }
             
             [Test]
@@ -332,7 +332,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
             {
                 _harvestGatewayStub = new HarvestGatewayStub
                 {
-                    Developers = new[]
+                    BillablePeople = new[]
                     {
                         new HarvestDeveloper
                         {
@@ -347,7 +347,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 
                 _slackGatewayStub = new SlackGatewayStub
                 {
-                    Developers = new[]
+                    BillablePeople = new[]
                     {
                         new SlackDeveloper
                         {
@@ -366,10 +366,10 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     new TimeSheet { Hours = 0, UserId = 444 }, 5
                 ).ToArray();
                 
-                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
-                var response = getDevelopers.Execute();
+                var getBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
+                var response = getBillablePeople.Execute();
                 
-                response.Developers.Count.Should().Be(0);
+                response.BillablePeople.Count.Should().Be(0);
             }
             
             [Test]
@@ -377,7 +377,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
             {
                 _harvestGatewayStub = new HarvestGatewayStub
                 {
-                    Developers = new[]
+                    BillablePeople = new[]
                     {
                         new HarvestDeveloper
                         {
@@ -392,7 +392,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 
                 _slackGatewayStub = new SlackGatewayStub
                 {
-                    Developers = new[]
+                    BillablePeople = new[]
                     {
                         new SlackDeveloper
                         {
@@ -411,11 +411,11 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     new TimeSheet { Hours = 0, UserId = 444 }, 5
                 ).ToArray();
                 
-                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
-                var response = getDevelopers.Execute();
+                var getBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
+                var response = getBillablePeople.Execute();
                 
-                response.Developers.Count.Should().Be(1);
-                response.Developers.First().Id.Should().Be("U8723");
+                response.BillablePeople.Count.Should().Be(1);
+                response.BillablePeople.First().Id.Should().Be("U8723");
             }
             
             
@@ -424,7 +424,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
             {
                 _harvestGatewayStub = new HarvestGatewayStub
                 {
-                    Developers = new[]
+                    BillablePeople = new[]
                     {
                         new HarvestDeveloper
                         {
@@ -439,7 +439,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 
                 _slackGatewayStub = new SlackGatewayStub
                 {
-                    Developers = new[]
+                    BillablePeople = new[]
                     {
                         new SlackDeveloper
                         {
@@ -458,11 +458,11 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     new TimeSheet { Hours = 0, UserId = 444 }, 5
                 ).ToArray();
                 
-                var getDevelopers = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
-                var response = getDevelopers.Execute();
+                var getBillablePeople = new GetLateBillablePeople(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, _clock);
+                var response = getBillablePeople.Execute();
                 
-                response.Developers.Count.Should().Be(1);
-                response.Developers.First().Id.Should().Be("U8723");
+                response.BillablePeople.Count.Should().Be(1);
+                response.BillablePeople.First().Id.Should().Be("U8723");
             }
         }
     }

--- a/CryptoTechReminderSystem.Test/UseCase/ListLateDevelopersTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/ListLateDevelopersTests.cs
@@ -37,7 +37,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
         }
 
         [Test]
-        public void CanRemindDevelopers()
+        public void CanRemindBillablePeople()
         {
             var listLateBillablePeople = new ListLateBillablePeople(_getLateBillablePeopleSpy, _sendReminderSpy);
 

--- a/CryptoTechReminderSystem.Test/UseCase/ListLateDevelopersTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/ListLateDevelopersTests.cs
@@ -8,17 +8,17 @@ using NUnit.Framework;
 
 namespace CryptoTechReminderSystem.Test.UseCase
 {
-    public class ListLateDevelopersTests
+    public class ListLateBillablePeopleTests
     {
         private SendReminderSpy _sendReminderSpy;
-        private GetLateDevelopersSpy _getLateDevelopersSpy;
+        private GetLateBillablePeopleSpy _getLateBillablePeopleSpy;
         private ClockStub _clock;
 
         [SetUp]
         public void SetUp()
         {
             _sendReminderSpy = new SendReminderSpy();
-            _getLateDevelopersSpy = new GetLateDevelopersSpy();
+            _getLateBillablePeopleSpy = new GetLateBillablePeopleSpy();
             _clock = new ClockStub(
                 new DateTimeOffset(
                     new DateTime(2019, 03, 01, 13, 30, 0)
@@ -27,24 +27,24 @@ namespace CryptoTechReminderSystem.Test.UseCase
         }
         
         [Test]
-        public void CanGetLateDevelopers()
+        public void CanGetLateBillablePeople()
         {
-            var listLateDevelopers = new ListLateDevelopers(_getLateDevelopersSpy, _sendReminderSpy);
+            var listLateBillablePeople = new ListLateBillablePeople(_getLateBillablePeopleSpy, _sendReminderSpy);
 
-            listLateDevelopers.Execute(new ListLateDevelopersRequest());
+            listLateBillablePeople.Execute(new ListLateBillablePeopleRequest());
 
-            _getLateDevelopersSpy.Called.Should().BeTrue();
+            _getLateBillablePeopleSpy.Called.Should().BeTrue();
         }
 
         [Test]
         public void CanRemindDevelopers()
         {
-            var listLateDevelopers = new ListLateDevelopers(_getLateDevelopersSpy, _sendReminderSpy);
+            var listLateBillablePeople = new ListLateBillablePeople(_getLateBillablePeopleSpy, _sendReminderSpy);
 
-            listLateDevelopers.Execute(
-                new ListLateDevelopersRequest
+            listLateBillablePeople.Execute(
+                new ListLateBillablePeopleRequest
                 {
-                    LateDevelopersMessage = "TIMESHEETS ARE GOOD YO!"
+                    LateBillablePeopleMessage = "TIMESHEETS ARE GOOD YO!"
                 }
             );
 
@@ -54,33 +54,33 @@ namespace CryptoTechReminderSystem.Test.UseCase
         [Test]
         [TestCase( "W0123CHAN", "W123AMON", "W789ROSS")]
         [TestCase( "W0123CHAN", "W123AMON")]
-        public void CanCheckLateDevelopersMessageHasAllUsers(params string[] userId)
+        public void CanCheckLateBillablePeopleMessageHasAllUsers(params string[] userId)
         {
-            var getLateDevelopersStub = new GetLateDevelopersStub(userId.ToList());
-            var listLateDevelopers = new ListLateDevelopers(getLateDevelopersStub, _sendReminderSpy);
-            var expectedLateDevelopersMessage = "TIMESHEETS ARE GOOD YO!";
+            var GetLateBillablePeopleStub = new GetLateBillablePeopleStub(userId.ToList());
+            var listLateBillablePeople = new ListLateBillablePeople(GetLateBillablePeopleStub, _sendReminderSpy);
+            var expectedLateBillablePeopleMessage = "TIMESHEETS ARE GOOD YO!";
 
-            listLateDevelopers.Execute(
-                new ListLateDevelopersRequest
+            listLateBillablePeople.Execute(
+                new ListLateBillablePeopleRequest
                 {
-                    LateDevelopersMessage = expectedLateDevelopersMessage
+                    LateBillablePeopleMessage = expectedLateBillablePeopleMessage
                 }
             );
 
-            expectedLateDevelopersMessage = userId.Aggregate(expectedLateDevelopersMessage, (current, user) => current + $"\n• <@{user}>");
+            expectedLateBillablePeopleMessage = userId.Aggregate(expectedLateBillablePeopleMessage, (current, user) => current + $"\n• <@{user}>");
 
-            _sendReminderSpy.Text.Should().Be(expectedLateDevelopersMessage);
+            _sendReminderSpy.Text.Should().Be(expectedLateBillablePeopleMessage);
         }
 
         [Test]
         public void CanCheckMessageHadChannel()
         {
-            var listLateDevelopers = new ListLateDevelopers(_getLateDevelopersSpy, _sendReminderSpy);
+            var listLateBillablePeople = new ListLateBillablePeople(_getLateBillablePeopleSpy, _sendReminderSpy);
 
             const string expectedChannel = "CH123456";
             
-            listLateDevelopers.Execute(
-                new ListLateDevelopersRequest
+            listLateBillablePeople.Execute(
+                new ListLateBillablePeopleRequest
                 {
                     Channel = expectedChannel
                 }
@@ -90,20 +90,20 @@ namespace CryptoTechReminderSystem.Test.UseCase
         }
 
         [Test]
-        public void CanSendNoLateDevelopersMessageWhenNoLateDevelopers()
+        public void CanSendNoLateBillablePeopleMessageWhenNoLateBillablePeople()
         {
-            var getLateDevelopersEmptyStub = new GetLateDevelopersEmptyStub();
-            var listLateDevelopers = new ListLateDevelopers(getLateDevelopersEmptyStub, _sendReminderSpy);
-            const string expectedNoLateDevelopersMessage = "Everyone has submitted their timesheets!";
+            var getLateBillablePeopleEmptyStub = new GetLateBillablePeopleEmptyStub();
+            var listLateBillablePeople = new ListLateBillablePeople(getLateBillablePeopleEmptyStub, _sendReminderSpy);
+            const string expectedNoLateBillablePeopleMessage = "Everyone has submitted their timesheets!";
 
-            listLateDevelopers.Execute(
-                new ListLateDevelopersRequest
+            listLateBillablePeople.Execute(
+                new ListLateBillablePeopleRequest
                 {
-                    NoLateDevelopersMessage = expectedNoLateDevelopersMessage
+                    NoLateBillablePeopleMessage = expectedNoLateBillablePeopleMessage
                 }
             );
 
-            _sendReminderSpy.Text.Should().Be(expectedNoLateDevelopersMessage);
+            _sendReminderSpy.Text.Should().Be(expectedNoLateBillablePeopleMessage);
         }
     }
 }

--- a/CryptoTechReminderSystem.Test/UseCase/RemindDeveloperTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/RemindDeveloperTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 
 namespace CryptoTechReminderSystem.Test.UseCase
 {
-    public class RemindDeveloperTests
+    public class RemindBillablePersonTests
     {
         private const string Text = "Please make sure your timesheet is submitted today by 13:30.";
 
@@ -24,12 +24,12 @@ namespace CryptoTechReminderSystem.Test.UseCase
         }
        
         [Test]
-        public void CanRemindDeveloper()
+        public void CanRemindBillablePerson()
         {
             var spy = new SlackGatewaySpy();
-            var remindDeveloper = new SendReminder(spy);
+            var remindBillablePerson = new SendReminder(spy);
             
-            remindDeveloper.Execute(new SendReminderRequest
+            remindBillablePerson.Execute(new SendReminderRequest
             {
                 Channel = "U120123D",
                 Text = Text
@@ -39,12 +39,12 @@ namespace CryptoTechReminderSystem.Test.UseCase
         }
         
         [Test]
-        public void CanRemindDeveloper2()
+        public void CanRemindBillablePerson2()
         {
             var spy = new SlackGatewaySpy();
-            var remindDeveloper = new SendReminder(spy);
+            var remindBillablePerson = new SendReminder(spy);
 
-            remindDeveloper.Execute(new SendReminderRequest
+            remindBillablePerson.Execute(new SendReminderRequest
             {
                 Channel = "U87219AW",
                 Text = Text

--- a/CryptoTechReminderSystem.Test/UseCase/RemindLateDevelopersTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/RemindLateDevelopersTests.cs
@@ -42,7 +42,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
         }
         
         [Test]
-        public void CanRemindDevelopers()
+        public void CanRemindBillablePeople()
         {
             HandleSetUp(_getLateBillablePeopleStub);
 
@@ -58,7 +58,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
         }
         
         [Test]
-        public void CanRemindDevelopersDirectly()
+        public void CanRemindBillablePeopleDirectly()
         {
             HandleSetUp(_getLateBillablePeopleStub);
             
@@ -72,7 +72,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
         }
         
         [Test]
-        public void CanRemindDevelopersDirectlyWithAMessage()
+        public void CanRemindBillablePeopleDirectlyWithAMessage()
         {
             HandleSetUp(_getLateBillablePeopleStub);
 

--- a/CryptoTechReminderSystem.Test/UseCase/RemindLateDevelopersTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/RemindLateDevelopersTests.cs
@@ -7,26 +7,26 @@ using NUnit.Framework;
 
 namespace CryptoTechReminderSystem.Test.UseCase
 {
-    public class RemindLateDevelopersTests
+    public class RemindLateBillablePeopleTests
     {
         private SendReminderSpy _sendReminderSpy;
-        private GetLateDevelopersSpy _getLateDevelopersSpy;
-        private GetLateDevelopersStub _getLateDevelopersStub;
+        private GetLateBillablePeopleSpy _getLateBillablePeopleSpy;
+        private GetLateBillablePeopleStub _getLateBillablePeopleStub;
 
         [SetUp]
         public void SetUp()
         {
             _sendReminderSpy = new SendReminderSpy();
-            _getLateDevelopersSpy = new GetLateDevelopersSpy();
-            _getLateDevelopersStub = new GetLateDevelopersStub();  
+            _getLateBillablePeopleSpy = new GetLateBillablePeopleSpy();
+            _getLateBillablePeopleStub = new GetLateBillablePeopleStub();  
         }
         
-        private void HandleSetUp(IGetLateDevelopers getLateDevelopers)
+        private void HandleSetUp(IGetLateBillablePeople GetLateBillablePeople)
         {
-            var remindLateDevelopers = new RemindLateDevelopers(getLateDevelopers, _sendReminderSpy);
+            var remindLateBillablePeople = new RemindLateBillablePeople(GetLateBillablePeople, _sendReminderSpy);
             
-            remindLateDevelopers.Execute(
-                new RemindLateDevelopersRequest
+            remindLateBillablePeople.Execute(
+                new RemindLateBillablePeopleRequest
                 {
                     Message = "TIMESHEETS ARE GOOD YO!"
                 }
@@ -34,25 +34,25 @@ namespace CryptoTechReminderSystem.Test.UseCase
         }
         
         [Test]
-        public void CanGetLateDevelopers()
+        public void CanGetLateBillablePeople()
         {
-            HandleSetUp(_getLateDevelopersSpy);
+            HandleSetUp(_getLateBillablePeopleSpy);
                
-            _getLateDevelopersSpy.Called.Should().BeTrue(); 
+            _getLateBillablePeopleSpy.Called.Should().BeTrue(); 
         }
         
         [Test]
         public void CanRemindDevelopers()
         {
-            HandleSetUp(_getLateDevelopersStub);
+            HandleSetUp(_getLateBillablePeopleStub);
 
             _sendReminderSpy.Called.Should().BeTrue(); 
         }
         
         [Test]
-        public void CanRemindAllLateDevelopers()
+        public void CanRemindAllLateBillablePeople()
         {
-           HandleSetUp(_getLateDevelopersStub);
+           HandleSetUp(_getLateBillablePeopleStub);
 
             _sendReminderSpy.CountCalled.Should().Be(3);
         }
@@ -60,7 +60,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
         [Test]
         public void CanRemindDevelopersDirectly()
         {
-            HandleSetUp(_getLateDevelopersStub);
+            HandleSetUp(_getLateBillablePeopleStub);
             
             _sendReminderSpy.Channels.Should().BeEquivalentTo(
                 new List<string> {
@@ -74,7 +74,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
         [Test]
         public void CanRemindDevelopersDirectlyWithAMessage()
         {
-            HandleSetUp(_getLateDevelopersStub);
+            HandleSetUp(_getLateBillablePeopleStub);
 
             _sendReminderSpy.Text.Should().Be("TIMESHEETS ARE GOOD YO!");
         }   

--- a/CryptoTechReminderSystem/Boundary/GetLateDevelopersResponse.cs
+++ b/CryptoTechReminderSystem/Boundary/GetLateDevelopersResponse.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace CryptoTechReminderSystem.Boundary
 {
-    public class GetLateDevelopersResponse
+    public class GetLateBillablePeopleResponse
     {
         public List<LateDeveloper> Developers;
 

--- a/CryptoTechReminderSystem/Boundary/GetLateDevelopersResponse.cs
+++ b/CryptoTechReminderSystem/Boundary/GetLateDevelopersResponse.cs
@@ -4,9 +4,9 @@ namespace CryptoTechReminderSystem.Boundary
 {
     public class GetLateBillablePeopleResponse
     {
-        public List<LateDeveloper> BillablePeople;
+        public List<LateBillablePerson> BillablePeople;
 
-        public class LateDeveloper
+        public class LateBillablePerson
         {
             public string Id { get; set; }
             public string Email { get; set; }

--- a/CryptoTechReminderSystem/Boundary/GetLateDevelopersResponse.cs
+++ b/CryptoTechReminderSystem/Boundary/GetLateDevelopersResponse.cs
@@ -4,7 +4,7 @@ namespace CryptoTechReminderSystem.Boundary
 {
     public class GetLateBillablePeopleResponse
     {
-        public List<LateDeveloper> Developers;
+        public List<LateDeveloper> BillablePeople;
 
         public class LateDeveloper
         {

--- a/CryptoTechReminderSystem/Boundary/ListLateDevelopersRequest.cs
+++ b/CryptoTechReminderSystem/Boundary/ListLateDevelopersRequest.cs
@@ -1,9 +1,9 @@
 namespace CryptoTechReminderSystem.Boundary
 {
-    public class ListLateDevelopersRequest
+    public class ListLateBillablePeopleRequest
     {
-        public string LateDevelopersMessage { get; set; }
-        public string NoLateDevelopersMessage { get; set; }
+        public string LateBillablePeopleMessage { get; set; }
+        public string NoLateBillablePeopleMessage { get; set; }
         public string Channel { get; set; }
     }
 }

--- a/CryptoTechReminderSystem/Boundary/RemindLateDevelopersRequest.cs
+++ b/CryptoTechReminderSystem/Boundary/RemindLateDevelopersRequest.cs
@@ -1,6 +1,6 @@
 namespace CryptoTechReminderSystem.Boundary
 {
-    public class RemindLateDevelopersRequest
+    public class RemindLateBillablePeopleRequest
     {
         public string Message { get; set; }
     }

--- a/CryptoTechReminderSystem/DomainObject/Developer.cs
+++ b/CryptoTechReminderSystem/DomainObject/Developer.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace CryptoTechReminderSystem.DomainObject
 {
-    public class Developer
+    public class BillablePerson
     {
         [JsonProperty("first_name")] 
         public string FirstName { get; set; }

--- a/CryptoTechReminderSystem/DomainObject/HarvestDeveloper.cs
+++ b/CryptoTechReminderSystem/DomainObject/HarvestDeveloper.cs
@@ -1,6 +1,6 @@
 namespace CryptoTechReminderSystem.DomainObject
 {
-    public class HarvestDeveloper : Developer
+    public class HarvestBillablePerson : BillablePerson
     {
         public int Id { get; set; }
     }

--- a/CryptoTechReminderSystem/DomainObject/SlackDeveloper.cs
+++ b/CryptoTechReminderSystem/DomainObject/SlackDeveloper.cs
@@ -1,6 +1,6 @@
 namespace CryptoTechReminderSystem.DomainObject
 {
-    public class SlackDeveloper : Developer
+    public class SlackBillablePerson : BillablePerson
     {
         public string Id { get; set; }
     }

--- a/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
@@ -25,7 +25,7 @@ namespace CryptoTechReminderSystem.Gateway
             _client.DefaultRequestHeaders.Add("User-Agent",userAgent);
         }
         
-        public IList<HarvestDeveloper> RetrieveDevelopers()
+        public IList<HarvestDeveloper> RetrieveBillablePeople()
         {
             var response = GetApiResponse(UsersApiAddress);
             
@@ -33,9 +33,9 @@ namespace CryptoTechReminderSystem.Gateway
             
             var apiResponse = response.Result;
             var users = apiResponse["users"];
-            var activeDevelopers = users.Where(user => (bool)user["is_active"] && IsDeveloper(user));
+            var activeBillablePeople = users.Where(user => (bool)user["is_active"] && IsDeveloper(user));
             
-            return activeDevelopers.Select(developer => new HarvestDeveloper
+            return activeBillablePeople.Select(developer => new HarvestDeveloper
                 {
                     Id = (int) developer["id"],
                     FirstName = developer["first_name"].ToString(),

--- a/CryptoTechReminderSystem/Gateway/IHarvestDeveloperRetriever.cs
+++ b/CryptoTechReminderSystem/Gateway/IHarvestDeveloperRetriever.cs
@@ -3,8 +3,8 @@ using CryptoTechReminderSystem.DomainObject;
 
 namespace CryptoTechReminderSystem.Gateway
 {
-    public interface IHarvestDeveloperRetriever
+    public interface IHarvestBillablePersonRetriever
     {
-        IList<HarvestDeveloper> RetrieveBillablePeople();
+        IList<HarvestBillablePerson> RetrieveBillablePeople();
     }
 }

--- a/CryptoTechReminderSystem/Gateway/IHarvestDeveloperRetriever.cs
+++ b/CryptoTechReminderSystem/Gateway/IHarvestDeveloperRetriever.cs
@@ -5,6 +5,6 @@ namespace CryptoTechReminderSystem.Gateway
 {
     public interface IHarvestDeveloperRetriever
     {
-        IList<HarvestDeveloper> RetrieveDevelopers();
+        IList<HarvestDeveloper> RetrieveBillablePeople();
     }
 }

--- a/CryptoTechReminderSystem/Gateway/ISlackDeveloperRetriever.cs
+++ b/CryptoTechReminderSystem/Gateway/ISlackDeveloperRetriever.cs
@@ -3,8 +3,8 @@ using CryptoTechReminderSystem.DomainObject;
 
 namespace CryptoTechReminderSystem.Gateway
 {
-    public interface ISlackDeveloperRetriever
+    public interface ISlackBillablePersonRetriever
     {
-        IList<SlackDeveloper> RetrieveBillablePeople();
+        IList<SlackBillablePerson> RetrieveBillablePeople();
     }
 }

--- a/CryptoTechReminderSystem/Gateway/ISlackDeveloperRetriever.cs
+++ b/CryptoTechReminderSystem/Gateway/ISlackDeveloperRetriever.cs
@@ -5,6 +5,6 @@ namespace CryptoTechReminderSystem.Gateway
 {
     public interface ISlackDeveloperRetriever
     {
-        IList<SlackDeveloper> RetrieveDevelopers();
+        IList<SlackDeveloper> RetrieveBillablePeople();
     }
 }

--- a/CryptoTechReminderSystem/Gateway/SlackGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/SlackGateway.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json.Linq;
 
 namespace CryptoTechReminderSystem.Gateway
 {
-    public class SlackGateway : IMessageSender, ISlackDeveloperRetriever
+    public class SlackGateway : IMessageSender, ISlackBillablePersonRetriever
     {
         private readonly HttpClient _client;
         private readonly string _token;
@@ -48,7 +48,7 @@ namespace CryptoTechReminderSystem.Gateway
                 .OfError(new Exception(response.Result["error"].ToString() ?? "Default error message"));
         }
         
-        public IList<SlackDeveloper> RetrieveBillablePeople()
+        public IList<SlackBillablePerson> RetrieveBillablePeople()
         {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _token);
 
@@ -62,10 +62,10 @@ namespace CryptoTechReminderSystem.Gateway
             return users.Where(user => user["profile"]["email"] != null && 
                                        (bool) user["deleted"] != true &&
                                        (bool) user["is_ultra_restricted"] != true)
-            .Select(developer => new SlackDeveloper
+            .Select(billablePerson => new SlackBillablePerson
                 {
-                    Id = developer["id"].ToString(),
-                    Email = developer["profile"]["email"].ToString()
+                    Id = billablePerson["id"].ToString(),
+                    Email = billablePerson["profile"]["email"].ToString()
                 }
             ).ToList();
         }

--- a/CryptoTechReminderSystem/Gateway/SlackGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/SlackGateway.cs
@@ -48,7 +48,7 @@ namespace CryptoTechReminderSystem.Gateway
                 .OfError(new Exception(response.Result["error"].ToString() ?? "Default error message"));
         }
         
-        public IList<SlackDeveloper> RetrieveDevelopers()
+        public IList<SlackDeveloper> RetrieveBillablePeople()
         {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _token);
 

--- a/CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs
@@ -6,14 +6,14 @@ using CryptoTechReminderSystem.Gateway;
 
 namespace CryptoTechReminderSystem.UseCase
 {
-    public class GetLateDevelopers : IGetLateDevelopers
+    public class GetLateBillablePeople : IGetLateBillablePeople
     {
         private readonly IHarvestDeveloperRetriever _harvestDeveloperRetriever;
         private readonly ITimeSheetRetriever _harvestTimeSheetRetriever;
         private readonly ISlackDeveloperRetriever _slackDeveloperRetriever;
         private readonly IClock _clock;
 
-        public GetLateDevelopers(ISlackDeveloperRetriever slackDeveloperRetriever, IHarvestDeveloperRetriever harvestDeveloperRetriever, ITimeSheetRetriever harvestTimeSheetRetriever, IClock clock)
+        public GetLateBillablePeople(ISlackDeveloperRetriever slackDeveloperRetriever, IHarvestDeveloperRetriever harvestDeveloperRetriever, ITimeSheetRetriever harvestTimeSheetRetriever, IClock clock)
         {
             _harvestDeveloperRetriever = harvestDeveloperRetriever;
             _harvestTimeSheetRetriever = harvestTimeSheetRetriever;
@@ -21,14 +21,14 @@ namespace CryptoTechReminderSystem.UseCase
             _clock = clock;
         }
         
-        public GetLateDevelopersResponse Execute()
+        public GetLateBillablePeopleResponse Execute()
         {
-            var getLateDevelopersResponse = new GetLateDevelopersResponse
+            var getLateBillablePeopleResponse = new GetLateBillablePeopleResponse
             {
-                Developers = new List<GetLateDevelopersResponse.LateDeveloper>()
+                Developers = new List<GetLateBillablePeopleResponse.LateDeveloper>()
             };
             
-            if (IsWeekend(_clock.Now())) return getLateDevelopersResponse;
+            if (IsWeekend(_clock.Now())) return getLateBillablePeopleResponse;
             
             var harvestGetDevelopersResponse = _harvestDeveloperRetriever.RetrieveDevelopers();
             var slackGetDevelopersResponse = _slackDeveloperRetriever.RetrieveDevelopers();
@@ -49,7 +49,7 @@ namespace CryptoTechReminderSystem.UseCase
                     
                     if (slackLateDeveloper != null)
                     {
-                        getLateDevelopersResponse.Developers.Add(new GetLateDevelopersResponse.LateDeveloper
+                        getLateBillablePeopleResponse.Developers.Add(new GetLateBillablePeopleResponse.LateDeveloper
                         {
                             Id = slackLateDeveloper.Id,
                             Email = slackLateDeveloper.Email
@@ -57,7 +57,7 @@ namespace CryptoTechReminderSystem.UseCase
                     }
                 }
             }
-            return getLateDevelopersResponse;
+            return getLateBillablePeopleResponse;
         }
         private static DateTimeOffset GetStartingDate(DateTimeOffset currentDateTime)
         {

--- a/CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs
@@ -25,31 +25,31 @@ namespace CryptoTechReminderSystem.UseCase
         {
             var getLateBillablePeopleResponse = new GetLateBillablePeopleResponse
             {
-                Developers = new List<GetLateBillablePeopleResponse.LateDeveloper>()
+                BillablePeople = new List<GetLateBillablePeopleResponse.LateDeveloper>()
             };
             
             if (IsWeekend(_clock.Now())) return getLateBillablePeopleResponse;
             
-            var harvestGetDevelopersResponse = _harvestDeveloperRetriever.RetrieveDevelopers();
-            var slackGetDevelopersResponse = _slackDeveloperRetriever.RetrieveDevelopers();
+            var harvestGetBillablePeopleResponse = _harvestDeveloperRetriever.RetrieveBillablePeople();
+            var slackGetBillablePeopleResponse = _slackDeveloperRetriever.RetrieveBillablePeople();
 
             var dateFrom = GetStartingDate(_clock.Now());
             var dateTo = GetEndingDate(_clock.Now());
             
             var harvestGetTimeSheetsResponse = _harvestTimeSheetRetriever.RetrieveTimeSheets(dateFrom, dateTo);
             
-            foreach (var harvestDeveloper in harvestGetDevelopersResponse)
+            foreach (var harvestDeveloper in harvestGetBillablePeopleResponse)
             {
                 var timeSheetForDeveloper = harvestGetTimeSheetsResponse.Where(sheet => sheet.UserId == harvestDeveloper.Id);
                 var sumOfHours = timeSheetForDeveloper.Sum(timeSheet => timeSheet.Hours);
                 
                 if (sumOfHours < ExpectedHoursByDate(harvestDeveloper.WeeklyHours, _clock.Now()))
                 {
-                    var slackLateDeveloper = slackGetDevelopersResponse.SingleOrDefault(developer => String.Equals(RemoveTopLevelDomain(developer.Email), RemoveTopLevelDomain(harvestDeveloper.Email), StringComparison.OrdinalIgnoreCase));
+                    var slackLateDeveloper = slackGetBillablePeopleResponse.SingleOrDefault(developer => String.Equals(RemoveTopLevelDomain(developer.Email), RemoveTopLevelDomain(harvestDeveloper.Email), StringComparison.OrdinalIgnoreCase));
                     
                     if (slackLateDeveloper != null)
                     {
-                        getLateBillablePeopleResponse.Developers.Add(new GetLateBillablePeopleResponse.LateDeveloper
+                        getLateBillablePeopleResponse.BillablePeople.Add(new GetLateBillablePeopleResponse.LateDeveloper
                         {
                             Id = slackLateDeveloper.Id,
                             Email = slackLateDeveloper.Email

--- a/CryptoTechReminderSystem/UseCase/IGetLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/IGetLateDevelopers.cs
@@ -2,8 +2,8 @@ using CryptoTechReminderSystem.Boundary;
 
 namespace CryptoTechReminderSystem.UseCase
 {
-    public interface IGetLateDevelopers
+    public interface IGetLateBillablePeople
     {
-        GetLateDevelopersResponse Execute();
+        GetLateBillablePeopleResponse Execute();
     }
 }

--- a/CryptoTechReminderSystem/UseCase/ListLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/ListLateDevelopers.cs
@@ -26,7 +26,7 @@ namespace CryptoTechReminderSystem.UseCase
             {
                 text = lateBillablePeople.BillablePeople.Aggregate(
                     listLateBillablePeopleRequest.LateBillablePeopleMessage, 
-                    (current, developer) => current + $"\n• <@{developer.Id}>"
+                    (current, billablePerson) => current + $"\n• <@{billablePerson.Id}>"
                 );
             }
 

--- a/CryptoTechReminderSystem/UseCase/ListLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/ListLateDevelopers.cs
@@ -19,12 +19,12 @@ namespace CryptoTechReminderSystem.UseCase
             var lateBillablePeople = _getLateBillablePeople.Execute();
             string text;
 
-            if (!lateBillablePeople.Developers.Any())
+            if (!lateBillablePeople.BillablePeople.Any())
             {
                 text = listLateBillablePeopleRequest.NoLateBillablePeopleMessage;
             } else
             {
-                text = lateBillablePeople.Developers.Aggregate(
+                text = lateBillablePeople.BillablePeople.Aggregate(
                     listLateBillablePeopleRequest.LateBillablePeopleMessage, 
                     (current, developer) => current + $"\n• <@{developer.Id}>"
                 );

--- a/CryptoTechReminderSystem/UseCase/ListLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/ListLateDevelopers.cs
@@ -3,29 +3,29 @@ using CryptoTechReminderSystem.Boundary;
 
 namespace CryptoTechReminderSystem.UseCase
 {
-    public class ListLateDevelopers
+    public class ListLateBillablePeople
     {
-        private readonly IGetLateDevelopers _getLateDevelopers;
+        private readonly IGetLateBillablePeople _getLateBillablePeople;
         private readonly ISendReminder _sendReminder;
 
-        public ListLateDevelopers(IGetLateDevelopers getLateDevelopers, ISendReminder sendReminder)
+        public ListLateBillablePeople(IGetLateBillablePeople getLateBillablePeople, ISendReminder sendReminder)
         {
-            _getLateDevelopers = getLateDevelopers;
+            _getLateBillablePeople = getLateBillablePeople;
             _sendReminder = sendReminder;
         }
 
-        public void Execute(ListLateDevelopersRequest listLateDevelopersRequest)
+        public void Execute(ListLateBillablePeopleRequest listLateBillablePeopleRequest)
         {
-            var lateDevelopers = _getLateDevelopers.Execute();
+            var lateBillablePeople = _getLateBillablePeople.Execute();
             string text;
 
-            if (!lateDevelopers.Developers.Any())
+            if (!lateBillablePeople.Developers.Any())
             {
-                text = listLateDevelopersRequest.NoLateDevelopersMessage;
+                text = listLateBillablePeopleRequest.NoLateBillablePeopleMessage;
             } else
             {
-                text = lateDevelopers.Developers.Aggregate(
-                    listLateDevelopersRequest.LateDevelopersMessage, 
+                text = lateBillablePeople.Developers.Aggregate(
+                    listLateBillablePeopleRequest.LateBillablePeopleMessage, 
                     (current, developer) => current + $"\n• <@{developer.Id}>"
                 );
             }
@@ -33,7 +33,7 @@ namespace CryptoTechReminderSystem.UseCase
             _sendReminder.Execute(new SendReminderRequest
             {
                 Text = text,
-                Channel = listLateDevelopersRequest.Channel
+                Channel = listLateBillablePeopleRequest.Channel
             });
         }
     }

--- a/CryptoTechReminderSystem/UseCase/RemindLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/RemindLateDevelopers.cs
@@ -18,13 +18,13 @@ namespace CryptoTechReminderSystem.UseCase
         {
             var lateBillablePeople = _getLateBillablePeople.Execute();
             
-            foreach (var lateDeveloper in lateBillablePeople.BillablePeople)
+            foreach (var lateBillablePerson in lateBillablePeople.BillablePeople)
             {
                 _sendReminder.Execute(new SendReminderRequest
                 {
-                    Channel = lateDeveloper.Id,
+                    Channel = lateBillablePerson.Id,
                     Text = remindLateBillablePeopleRequest.Message,
-                    Email = lateDeveloper.Email
+                    Email = lateBillablePerson.Email
                 });
             }
         }

--- a/CryptoTechReminderSystem/UseCase/RemindLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/RemindLateDevelopers.cs
@@ -18,7 +18,7 @@ namespace CryptoTechReminderSystem.UseCase
         {
             var lateBillablePeople = _getLateBillablePeople.Execute();
             
-            foreach (var lateDeveloper in lateBillablePeople.Developers)
+            foreach (var lateDeveloper in lateBillablePeople.BillablePeople)
             {
                 _sendReminder.Execute(new SendReminderRequest
                 {

--- a/CryptoTechReminderSystem/UseCase/RemindLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/RemindLateDevelopers.cs
@@ -3,27 +3,27 @@ using CryptoTechReminderSystem.Boundary;
 
 namespace CryptoTechReminderSystem.UseCase
 {
-    public class RemindLateDevelopers
+    public class RemindLateBillablePeople
     {
-        private readonly IGetLateDevelopers _getLateDevelopers;
+        private readonly IGetLateBillablePeople _getLateBillablePeople;
         private readonly ISendReminder _sendReminder;
 
-        public RemindLateDevelopers(IGetLateDevelopers getLateDevelopers, ISendReminder sendReminder)
+        public RemindLateBillablePeople(IGetLateBillablePeople getLateBillablePeople, ISendReminder sendReminder)
         {
-            _getLateDevelopers = getLateDevelopers;
+            _getLateBillablePeople = getLateBillablePeople;
             _sendReminder = sendReminder;
         }
         
-        public void Execute(RemindLateDevelopersRequest remindLateDevelopersRequest)
+        public void Execute(RemindLateBillablePeopleRequest remindLateBillablePeopleRequest)
         {
-            var lateDevelopers = _getLateDevelopers.Execute();
+            var lateBillablePeople = _getLateBillablePeople.Execute();
             
-            foreach (var lateDeveloper in lateDevelopers.Developers)
+            foreach (var lateDeveloper in lateBillablePeople.Developers)
             {
                 _sendReminder.Execute(new SendReminderRequest
                 {
                     Channel = lateDeveloper.Id,
-                    Text = remindLateDevelopersRequest.Message,
+                    Text = remindLateBillablePeopleRequest.Message,
                     Email = lateDeveloper.Email
                 });
             }

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@
 
 ## About The Project
 
-The Wolves is a project developed by the Made Tech Academy of Winter/Spring 2019. It set out to solve the problem of developers not filling in their timesheets on time and the need for the Operations team to manually send reminders.
+The Wolves is a project developed by the Made Tech Academy of Winter/Spring 2019. It set out to solve the problem of billablePeople not filling in their timesheets on time and the need for the Operations team to manually send reminders.
 
-This application solves this problem by automatically reminding developers that have not submitted their timesheets through a Slack direct message and publicly listing all those yet to do so by the deadline.
+This application solves this problem by automatically reminding billable people that have not submitted their timesheets through a Slack direct message and publicly listing all those yet to do so by the deadline.
 
 <p align="center">
   <img src="images/the-wolves-reminder.png" alt="Logo" width="500">
@@ -52,8 +52,8 @@ The Wolves is a C# application that follows the principles of [Clean Architectur
 
 Following CA, we have two sea-level use cases:
 
-- [Remind Late Developers](CryptoTechReminderSystem/UseCase/RemindLateBillablePeople.cs)
-- [List Late Developers](CryptoTechReminderSystem/UseCase/ListLateBillablePeople.cs)
+- [Remind Late Billable people](CryptoTechReminderSystem/UseCase/RemindLateBillablePeople.cs)
+- [List Late Billable people](CryptoTechReminderSystem/UseCase/ListLateBillablePeople.cs)
 
 Each of which have use case dependencies on:
 
@@ -63,11 +63,11 @@ Each of which have use case dependencies on:
 We then have `CryptoTechReminderSystem.Main/Program.cs`, which schedules when the
 above use cases should be called. The Wolves have two jobs:
 
-- `RemindLateBillablePeopleJob` which sends a Slack direct message to developers who are
+- `RemindLateBillablePeopleJob` which sends a Slack direct message to billable people who are
   yet to fill in their timesheets at 10.30 on a Friday morning and then every 30 mins
   until 13:30
 - `ListLateBillablePeopleJob` which sends a Slack message to a public channel that
-  lists all the developers still yet to submit their timesheets at 13:30 on a Friday
+  lists all the billable people still yet to submit their timesheets at 13:30 on a Friday
   afternoon
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -52,21 +52,21 @@ The Wolves is a C# application that follows the principles of [Clean Architectur
 
 Following CA, we have two sea-level use cases:
 
-- [Remind Late Developers](CryptoTechReminderSystem/UseCase/RemindLateDevelopers.cs)
-- [List Late Developers](CryptoTechReminderSystem/UseCase/ListLateDevelopers.cs)
+- [Remind Late Developers](CryptoTechReminderSystem/UseCase/RemindLateBillablePeople.cs)
+- [List Late Developers](CryptoTechReminderSystem/UseCase/ListLateBillablePeople.cs)
 
 Each of which have use case dependencies on:
 
-- [GetLateDevelopers](CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs) which calls the [Harvest API](https://help.getharvest.com/api-v2/) to figure out who is yet to submit their timesheet
+- [GetLateBillablePeople](CryptoTechReminderSystem/UseCase/GetLateBillablePeople.cs) which calls the [Harvest API](https://help.getharvest.com/api-v2/) to figure out who is yet to submit their timesheet
 - [SendReminder](CryptoTechReminderSystem/UseCase/SendReminder.cs) which calls the [Slack API](https://api.slack.com/) to send out reminders
 
 We then have `CryptoTechReminderSystem.Main/Program.cs`, which schedules when the
 above use cases should be called. The Wolves have two jobs:
 
-- `RemindLateDevelopersJob` which sends a Slack direct message to developers who are
+- `RemindLateBillablePeopleJob` which sends a Slack direct message to developers who are
   yet to fill in their timesheets at 10.30 on a Friday morning and then every 30 mins
   until 13:30
-- `ListLateDevelopersJob` which sends a Slack message to a public channel that
+- `ListLateBillablePeopleJob` which sends a Slack message to a public channel that
   lists all the developers still yet to submit their timesheets at 13:30 on a Friday
   afternoon
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it?) -->
There are other roles on deliveries that are billable, using the term LateDevelopers is misleading and does not include all billable roles.

## Changes proposed in this pull request
<!-- What does this PR add, change, fix or remove? -->
This PR renames wherever we used `LateDevelopers` in use-cases to a more descriptive  `LateBillablePaople` 

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Did I miss anything? Please check carefully, I used `find-and-replace` and I run the tests, it seemed healthy.

## Link to issue/card
<!-- https://github.com/madetech/the-wolves/issues/123 -->
https://github.com/madetech/the-wolves/projects/2#card-35802703
