### PR TITLE
Add ability to use Heroku Exec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ WORKDIR /app
 # Copies the current directory to the image
 COPY . ./
 
+ADD ./.profile.d /app/.profile.d
+
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
 RUN dotnet restore
 
 RUN dotnet publish -o out

--- a/heroku-exec.sh
+++ b/heroku-exec.sh
@@ -1,0 +1,1 @@
+[ -z "$SSH_CLIENT" ] && source <(curl --fail --retry 3 -sSL "$HEROKU_EXEC_URL")


### PR DESCRIPTION
## Context

We're trying to improve our confidence that things still work when we update configuration and confirm that we get back what we expect. One way would be to create a task that we can run. See https://github.com/madetech/the-wolves/issues/56. To run a task it seems that using [Heroku Exec](https://devcenter.heroku.com/articles/exec#enabling-docker-support) is the way to go but doesn't seem to work atm because we don't have `bash` set up in our Dockerfile.

## Changes proposed in this pull request

This PR adds the necessary files according to the documentation on Heroku to set this up. 🤞 

## Guidance to review

https://devcenter.heroku.com/articles/exec#enabling-docker-support

## Link to issue/card

https://github.com/madetech/the-wolves/issues/56
