### PR TITLE
Handle pagination when retrieving users from Harvest API

### DIFF
--- a/CryptoTechReminderSystem.AcceptanceTest/ApiEndpointResponse/HarvestUsersResponse.json
+++ b/CryptoTechReminderSystem.AcceptanceTest/ApiEndpointResponse/HarvestUsersResponse.json
@@ -67,5 +67,8 @@
       ],
       "is_active":true
     }
-  ]
+  ],
+  "per_page":100,
+  "total_pages":1,
+  "page":1
 }

--- a/CryptoTechReminderSystem.AcceptanceTest/ApiEndpointResponse/HarvestUsersResponse.json
+++ b/CryptoTechReminderSystem.AcceptanceTest/ApiEndpointResponse/HarvestUsersResponse.json
@@ -68,7 +68,7 @@
       "is_active":true
     }
   ],
-  "per_page":100,
-  "total_pages":1,
-  "page":1
+  "per_page": 100,
+  "total_pages": 1,
+  "page": 1
 }

--- a/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
+++ b/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
@@ -74,7 +74,10 @@ namespace CryptoTechReminderSystem.AcceptanceTest
                 )
             );
             
-            _harvestApi.Get(HarvestApiUsersPath).Responds(harvestGetUsersResponse);
+            _harvestApi.Get(HarvestApiUsersPath)
+                .WithParameter("page", "1")
+                .WithParameter("per_page", "100")
+                .Responds(harvestGetUsersResponse);
             
             var harvestGetTimeEntriesResponse = File.ReadAllText(
                 Path.Combine(

--- a/CryptoTechReminderSystem.Test/CryptoTechReminderSystem.Test.csproj
+++ b/CryptoTechReminderSystem.Test/CryptoTechReminderSystem.Test.csproj
@@ -33,6 +33,12 @@
       <None Update="Gateway\ApiEndpointResponse\HarvestUsersResponse.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="Gateway\ApiEndpointResponse\HarvestUsersResponsePageOne.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="Gateway\ApiEndpointResponse\HarvestUsersResponsePageTwo.json">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
       <None Update="Gateway\ApiEndpointResponse\HarvestTimeEntriesApiEndpointPageOne.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>

--- a/CryptoTechReminderSystem.Test/Gateway/ApiEndpointResponse/HarvestUsersResponse.json
+++ b/CryptoTechReminderSystem.Test/Gateway/ApiEndpointResponse/HarvestUsersResponse.json
@@ -119,5 +119,11 @@
       ],
       "is_active":true
     }
-  ]
+  ],
+  "per_page":100,
+  "total_pages":1,
+  "total_entries":11,
+  "next_page":null,
+  "previous_page":null,
+  "page":1
 }

--- a/CryptoTechReminderSystem.Test/Gateway/ApiEndpointResponse/HarvestUsersResponsePageOne.json
+++ b/CryptoTechReminderSystem.Test/Gateway/ApiEndpointResponse/HarvestUsersResponsePageOne.json
@@ -1,0 +1,32 @@
+{
+  "users": [
+    {
+      "id": 1782974,
+      "first_name": "Bruce",
+      "last_name": "Wayne",
+      "email": "batman@gotham.com",
+      "weekly_capacity": 126000,
+      "roles": [
+        "Lead Engineer"
+      ],
+      "is_active":true
+    },
+    {
+      "id": 1782959,
+      "first_name": "Dick",
+      "last_name": "Grayson",
+      "email": "robin@gotham.com",
+      "weekly_capacity": 126000,
+      "roles": [
+        "Software Engineer"
+      ],
+      "is_active":true
+    }
+  ],
+  "per_page":2,
+  "total_pages":2,
+  "total_entries":3,
+  "next_page":2,
+  "previous_page":null,
+  "page":1
+}

--- a/CryptoTechReminderSystem.Test/Gateway/ApiEndpointResponse/HarvestUsersResponsePageTwo.json
+++ b/CryptoTechReminderSystem.Test/Gateway/ApiEndpointResponse/HarvestUsersResponsePageTwo.json
@@ -1,0 +1,21 @@
+{
+  "users": [
+    {
+      "id": 1710101,
+      "first_name": "Alfred",
+      "last_name": "Pennyworth",
+      "email": "alfred@gotham.com",
+      "weekly_capacity": 126000,
+      "roles": [
+        "Senior Software Engineer"
+      ],
+      "is_active":true
+    }
+  ],
+  "per_page":2,
+  "total_pages":2,
+  "total_entries":3,
+  "next_page":null,
+  "previous_page":1,
+  "page":2
+}

--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -59,7 +59,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
         [TestFixture]
         public class CanRequestBillablePeople
         {
-            private const string apiUsersPath = "/api/v2/users";
+            private const string ApiUsersPath = "/api/v2/users";
 
             [SetUp]
             public void Setup()
@@ -126,10 +126,10 @@ namespace CryptoTechReminderSystem.Test.Gateway
 
                 var response = _harvestGateway.RetrieveBillablePeople();
 
-                response.Count.Should().Be(3);
+                response.Should().HaveCount(3);
             }
 
-            private void SetUpUsersEndpointWithSinglePage()
+            private static void SetUpUsersEndpointWithSinglePage()
             {
                 var json = File.ReadAllText(
                     Path.Combine(
@@ -138,13 +138,13 @@ namespace CryptoTechReminderSystem.Test.Gateway
                     )
                 );
 
-                _harvestApi.Get(apiUsersPath)
+                _harvestApi.Get(ApiUsersPath)
                     .WithParameter("page", "1")
                     .WithParameter("per_page", "100")
                     .Responds(json);
                 _harvestApi.Start();
             }
-            private void SetUpUsersEndpointWithTwoPages()
+            private static void SetUpUsersEndpointWithTwoPages()
             {
                 var jsonPageOne = File.ReadAllText(
                     Path.Combine(
@@ -153,7 +153,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
                     )
                 );
 
-                _harvestApi.Get(apiUsersPath)
+                _harvestApi.Get(ApiUsersPath)
                     .WithParameter("page", "1")
                     .WithParameter("per_page", "100")
                     .Responds(jsonPageOne);
@@ -165,7 +165,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
                     )
                 );
 
-                _harvestApi.Get(apiUsersPath)
+                _harvestApi.Get(ApiUsersPath)
                     .WithParameter("page", "2")
                     .WithParameter("per_page", "100")
                     .Responds(jsonPageTwo);

--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -59,21 +59,13 @@ namespace CryptoTechReminderSystem.Test.Gateway
         [TestFixture]
         public class CanRequestBillablePeople
         {
+            private const string apiUsersPath = "/api/v2/users";
+
             [SetUp]
             public void Setup()
             {
                 _harvestApi = new FluentSimulator(Address);
                 _harvestGateway = new HarvestGateway(Address, Token, HarvestAccountId, UserAgent, BillablePersonRoles);
-
-                var json = File.ReadAllText(
-                    Path.Combine(
-                        AppDomain.CurrentDomain.BaseDirectory,
-                        "Gateway/ApiEndpointResponse/HarvestUsersResponse.json"
-                    )
-                );
-
-                _harvestApi.Get("/api/v2/users").Responds(json);
-                _harvestApi.Start();
             }
 
             [TearDown]
@@ -85,6 +77,8 @@ namespace CryptoTechReminderSystem.Test.Gateway
             [Test]
             public void CanSendOneRequestAtATime()
             {
+                SetUpUsersEndpointWithSinglePage();
+
                 _harvestGateway.RetrieveBillablePeople();
 
                 _harvestApi.ReceivedRequests.Count.Should().Be(1);
@@ -96,6 +90,8 @@ namespace CryptoTechReminderSystem.Test.Gateway
             [TestCase("User-Agent", UserAgent)]
             public void CanGetBillablePeopleWithHeaders(string header, string expected)
             {
+                SetUpUsersEndpointWithSinglePage();
+
                 _harvestGateway.RetrieveBillablePeople();
 
                 _harvestApi.ReceivedRequests.First().Headers[header].Should().Be(expected);
@@ -104,6 +100,8 @@ namespace CryptoTechReminderSystem.Test.Gateway
             [Test]
             public void CanOnlyGetActiveBillablePeople()
             {
+                SetUpUsersEndpointWithSinglePage();
+
                 var response = _harvestGateway.RetrieveBillablePeople();
 
                 response.First().FirstName.Should().Be("Dick");
@@ -115,8 +113,64 @@ namespace CryptoTechReminderSystem.Test.Gateway
             [TestCase("Harvey", 28)]
             public void CanGetWeeklyHoursForBillablePeople(string name, int hours)
             {
+                SetUpUsersEndpointWithSinglePage();
+
                 var response = _harvestGateway.RetrieveBillablePeople();
                 response.First(billablePerson => billablePerson.FirstName == name).WeeklyHours.Should().Be(hours);
+            }
+
+            [Test]
+            public void CanGetBillablePeopleWithPagination()
+            {
+                SetUpUsersEndpointWithTwoPages();
+
+                var response = _harvestGateway.RetrieveBillablePeople();
+
+                response.Count.Should().Be(3);
+            }
+
+            private void SetUpUsersEndpointWithSinglePage()
+            {
+                var json = File.ReadAllText(
+                    Path.Combine(
+                        AppDomain.CurrentDomain.BaseDirectory,
+                        "Gateway/ApiEndpointResponse/HarvestUsersResponse.json"
+                    )
+                );
+
+                _harvestApi.Get(apiUsersPath)
+                    .WithParameter("page", "1")
+                    .WithParameter("per_page", "100")
+                    .Responds(json);
+                _harvestApi.Start();
+            }
+            private void SetUpUsersEndpointWithTwoPages()
+            {
+                var jsonPageOne = File.ReadAllText(
+                    Path.Combine(
+                        AppDomain.CurrentDomain.BaseDirectory,
+                        "Gateway/ApiEndpointResponse/HarvestUsersResponsePageOne.json"
+                    )
+                );
+
+                _harvestApi.Get(apiUsersPath)
+                    .WithParameter("page", "1")
+                    .WithParameter("per_page", "100")
+                    .Responds(jsonPageOne);
+
+                var jsonPageTwo = File.ReadAllText(
+                    Path.Combine(
+                        AppDomain.CurrentDomain.BaseDirectory,
+                        "Gateway/ApiEndpointResponse/HarvestUsersResponsePageTwo.json"
+                    )
+                );
+
+                _harvestApi.Get(apiUsersPath)
+                    .WithParameter("page", "2")
+                    .WithParameter("per_page", "100")
+                    .Responds(jsonPageTwo);
+                
+                _harvestApi.Start();
             }
         }
 


### PR DESCRIPTION
## Context
Some billable people aren't reminded/listed on Fridays. The company grew over time and Harvest API Users endpoint responds with 100 users per page by default. We need to handle pagination to make sure every billable people is on the list.

## Changes proposed in this pull request
- Update `HarvestGateway#RetrieveBillalePeopleb` to handle pagination
- Refactor `HarvestGateway#RetrieveTimeSheets` to remove duplication