### PR TITLE
Feature/harvest caching

### DIFF
--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -137,7 +137,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
                 _harvestGateway.RetrieveBillablePeople();
                 _harvestGateway.RetrieveBillablePeople();
 
-                _harvestApi.ReceivedRequests.Count.Should().Be(1);
+                _harvestApi.ReceivedRequests.Should().HaveCount(1);
             }
 
             private static void SetUpUsersEndpointWithSinglePage()
@@ -358,7 +358,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
                 var response1 = _harvestGateway.RetrieveTimeSheets(_defaultDateFrom, _defaultDateTo);
                 var response2 = _harvestGateway.RetrieveTimeSheets(_defaultDateFrom, _defaultDateTo);
 
-                _harvestApi.ReceivedRequests.Count.Should().Be(1);
+                _harvestApi.ReceivedRequests.Should().HaveCount(1);
             }
         }
     }

--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -129,6 +129,17 @@ namespace CryptoTechReminderSystem.Test.Gateway
                 response.Should().HaveCount(3);
             }
 
+            [Test]
+            public void CanCacheBillablePeople()
+            {
+                SetUpUsersEndpointWithSinglePage();
+
+                _harvestGateway.RetrieveBillablePeople();
+                _harvestGateway.RetrieveBillablePeople();
+
+                _harvestApi.ReceivedRequests.Count.Should().Be(1);
+            }
+
             private static void SetUpUsersEndpointWithSinglePage()
             {
                 var json = File.ReadAllText(
@@ -349,6 +360,10 @@ namespace CryptoTechReminderSystem.Test.Gateway
 
                 _harvestApi.ReceivedRequests.Count.Should().Be(1);
             }
+
+            
+
+            
         }
     }
 }

--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -338,6 +338,17 @@ namespace CryptoTechReminderSystem.Test.Gateway
                 response.First().UserId.Should().Be(1782975);
                 response.First().Hours.Should().Be(7.0);
             }
+
+            [Test]
+            public void CanCacheTimeSheetResponses()
+            {
+                SetUpTimeSheetApiEndpointWithOnePage("2019-04-08", "2019-04-12");
+
+                var response1 = _harvestGateway.RetrieveTimeSheets(_defaultDateFrom, _defaultDateTo);
+                var response2 = _harvestGateway.RetrieveTimeSheets(_defaultDateFrom, _defaultDateTo);
+
+                _harvestApi.ReceivedRequests.Count.Should().Be(1);
+            }
         }
     }
 }

--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -360,10 +360,6 @@ namespace CryptoTechReminderSystem.Test.Gateway
 
                 _harvestApi.ReceivedRequests.Count.Should().Be(1);
             }
-
-            
-
-            
         }
     }
 }

--- a/CryptoTechReminderSystem/CryptoTechReminderSystem.csproj
+++ b/CryptoTechReminderSystem/CryptoTechReminderSystem.csproj
@@ -5,6 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 

--- a/CryptoTechReminderSystem/CryptoTechReminderSystem.csproj
+++ b/CryptoTechReminderSystem/CryptoTechReminderSystem.csproj
@@ -7,6 +7,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+      <PackageReference Include="Polly" Version="7.2.1" />
     </ItemGroup>
 
 </Project>

--- a/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
@@ -42,7 +42,7 @@ namespace CryptoTechReminderSystem.Gateway
             });
         }
         
-                public IList<HarvestBillablePerson> RetrieveBillablePeople()
+        public IList<HarvestBillablePerson> RetrieveBillablePeople()
         {
             var address = $"{UsersApiAddress}?per_page=100";
             
@@ -112,13 +112,12 @@ namespace CryptoTechReminderSystem.Gateway
 
         private async Task<JObject> GetApiResponse(string address)
         {   
-            int THROTTLE_TIME_IN_MS = 150;
-            int MAX_ATTEMPTS = 5;
-            
             var harvestRetryPolicy = Policy
                 .HandleResult<HttpResponseMessage>(r => r.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
-                .WaitAndRetryAsync(
-                    MAX_ATTEMPTS, attempt => TimeSpan.FromMilliseconds(THROTTLE_TIME_IN_MS * Math.Pow(2, attempt)));
+                .WaitAndRetryAsync(new[]
+                {
+                    TimeSpan.FromSeconds(15),
+                });
             
             var response = await harvestRetryPolicy.ExecuteAsync(() => (_client.GetAsync(address)));
                 

--- a/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
@@ -43,7 +43,16 @@ namespace CryptoTechReminderSystem.Gateway
         
         public IList<HarvestBillablePerson> RetrieveBillablePeople()
         {
-            var apiResponse = RetrieveWithPagination($"{UsersApiAddress}?per_page=100");
+            var endPoint = $"{UsersApiAddress}?per_page=100";
+            var cachePeriodDays = 1;
+            
+            var apiResponse = _cache.GetOrCreate(endPoint, cacheEntry => 
+            {
+                cacheEntry.AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(cachePeriodDays);
+                cacheEntry.SetSize(1);
+
+                return RetrieveWithPagination($"{UsersApiAddress}?per_page=100");
+            });
 
             var users = apiResponse["users"];
             var activeBillablePeople = users.Where(user => (bool)user["is_active"] && IsBillablePerson(user));


### PR DESCRIPTION
## Context

PR to resolve issue #70 by adding caching and a retrying policy to API requests made by HarvestGateway.  Merging this PR paves the way for #68 (being worked on in [feature/remind-project-managers](https://github.com/madetech/the-wolves/tree/feature/remind_project_managers)), which needs to make more API calls.

## Changes proposed in this pull request

- Use the C# [in-memory caching extension](https://docs.microsoft.com/en-us/aspnet/core/performance/caching/memory?view=aspnetcore-5.0) to add a private cache to `HarvestGateway`.
- Have `RetrieveBillablePeople()` and `RetrieveTimeSheets()` check the cache before hitting the API end-point.
- Use [Polly](https://github.com/App-vNext/Polly) library to retry requests after the API rejects due to "Too Many Requests" (with [exponential backoff](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly)).
- Refactor to group related private methods.
- Add unit tests for above.

## Guidance to review

I'd really appreciate feedback on:

- To avoid changing the public interface of HarvestGateway, the cache is 'new'd up' in the HarvestGateway constructor at line 39.  Is this OK?  I think we'd only want to inject a cache instance to test HarvestGateway more thoroughly (maybe with a mock/spy cache).  Would this be overkill?
- How could we test the retry policy?  I would like to have a stub return a HTTP 429 status on the first request then a valid response on the second request, but the FluentSimulator library only allows stubs to store a single response to requests.

Thank you 🙏🏻

## Link to issue/card

https://github.com/madetech/the-wolves/issues/70
